### PR TITLE
Fix lean build setup and add CI

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+  pull_request:
+
+name: build lean
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: install elan
+      run: |
+        set -o pipefail
+        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - uses: actions/checkout@v3
+    - name: Set up olean cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache
+        key: oleans
+
+    - name: Configure
+      run: |
+        lake exe cache get
+
+    - name: Build
+      run: |
+        lake build
+
+    - name: Save olean cache
+      run: |
+        lake exe cache pack

--- a/lean4/lakefile.lean
+++ b/lean4/lakefile.lean
@@ -3,8 +3,8 @@ open Lake DSL
 
 package «putnam» where
   -- add package configuration options here
-  require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.7.0-rc2"
+require mathlib from git "https://github.com/leanprover-community/mathlib4" @ "v4.7.0-rc2"
 
 @[default_target]
-lean_lib «putnam» {
-}
+lean_lib «putnam» where
+  globs := #[.submodules `src]


### PR DESCRIPTION
The `globs` field makes `lake build` work.

The CI script includes some basic caching which should prevent it doing any work if the lean files don't change.

Note that CI fails, because three of the lean files contain either type errors or invalid syntax; I would argue that CI that fails is better than no CI at all, and the fixes can come later.