### PR TITLE
Run lean CI in the right directory

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -24,16 +24,16 @@ jobs:
         key: oleans
 
     - name: Configure
+      working-directory: lean4
       run: |
-        cd lean4
         lake exe cache get
 
     - name: Build
+      working-directory: lean4
       run: |
-        cd lean4
         lake build
 
     - name: Save olean cache
+      working-directory: lean4
       run: |
-        cd lean4
         lake exe cache pack

--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -25,12 +25,15 @@ jobs:
 
     - name: Configure
       run: |
+        cd lean4
         lake exe cache get
 
     - name: Build
       run: |
+        cd lean4
         lake build
 
     - name: Save olean cache
       run: |
+        cd lean4
         lake exe cache pack


### PR DESCRIPTION
Follows up from #170, which was misconfigured.

If you look at the build logs, you will see that the build runs as expected, though fails on some files that genuinely have errors in them.