### PR TITLE
Remove `open BigOperators` which does nothing

### DIFF
--- a/lean4/scripts/generate_files_by_year.py
+++ b/lean4/scripts/generate_files_by_year.py
@@ -9,7 +9,7 @@ def all_to_years(min_year, max_year):
         for year in range(max_year, min_year - 1, -1):
             filename = f"putnam_{year}.lean"
             with open(filename, "w") as g:
-                g.write("import Mathlib\nopen BigOperators\n\n")
+                g.write("import Mathlib\n\n")
                 is_in_section = False
                 for line in lines:
                     if is_in_section:
@@ -21,14 +21,14 @@ def all_to_years(min_year, max_year):
 
 def years_to_all(min_year, max_year):
     with open("putnam_all.lean", "w") as f:
-        f.write("import Mathlib\nopen BigOperators\n\n")
+        f.write("import Mathlib\n\n")
         for year in range(min_year, max_year + 1):
             filename = f"putnam_{year}.lean"
             with open(filename, "r") as g:
                 lines = g.readlines()
                 f.write(f"section putnam_{year}\n")
                 for line in lines:
-                    if line.strip() == "import Mathlib" or line.strip() == "open BigOperators":
+                    if line.strip() == "import Mathlib":
                         continue
                     f.write(line)
                 f.write(f"end putnam_{year}\n")
@@ -45,7 +45,7 @@ def files_to_individual(min_year, max_year):
             problem_pattern = fr'putnam_{year}_[ab][1-6]'
 
             for idx, line in enumerate(lines):
-                if "Mathlib" in line or "BigOperators" in line:
+                if "Mathlib" in line:
                     continue
                 elif line.strip() == "" or idx == len(lines) - 1:
                     if idx == len(lines) - 1:
@@ -64,7 +64,7 @@ def files_to_individual(min_year, max_year):
                             print(f"Search is {search}")
                             assert False
                         with open(f"src/{problem_name}.lean", "w") as g:
-                            g.write("import Mathlib\nopen BigOperators\n\n")
+                            g.write("import Mathlib\n\n")
                             if len(running_scopes) > 0:
                                 g.write(f"open {' '.join(running_scopes)}\n\n")
                             for line in section_content:
@@ -106,7 +106,7 @@ def all_to_individual(min_year, max_year):
 
                     filename = f"putnam_{section_name}.lean"
                     with open(filename, "w") as g:
-                        g.write("import Mathlib\nopen BigOperators\n")
+                        g.write("import Mathlib\n")
                         for namespace in namespaces:
                             g.write(f"open {namespace}\n")
                         g.write("\n")

--- a/lean4/src/putnam_1962_a1.lean
+++ b/lean4/src/putnam_1962_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory
 

--- a/lean4/src/putnam_1962_a2.lean
+++ b/lean4/src/putnam_1962_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory Set
 

--- a/lean4/src/putnam_1962_a3.lean
+++ b/lean4/src/putnam_1962_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory
 

--- a/lean4/src/putnam_1962_a4.lean
+++ b/lean4/src/putnam_1962_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Assume that $\lvert f(x) \rvert \le 1$ and $\lvert f''(x) \rvert \le 1$ for all $x$ on an interval of length at least 2. Show that $\lvert f'(x) \rvert \le 2$ on the interval.

--- a/lean4/src/putnam_1962_a5.lean
+++ b/lean4/src/putnam_1962_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1962_a5_solution : ℕ → ℕ := sorry
 -- fun n : ℕ => n * (n + 1) * 2^(n - 2)

--- a/lean4/src/putnam_1962_a6.lean
+++ b/lean4/src/putnam_1962_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $S$ be a set of rational numbers such that whenever $a$ and $b$ are members of $S$, so are $a+b$ and $ab$, and having the property that for every rational number $r$ exactly one of the following three statements is true: \[ r \in S, -r \in S, r = 0. \] Prove that $S$ is the set of all positive rational numbers.

--- a/lean4/src/putnam_1962_b1.lean
+++ b/lean4/src/putnam_1962_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $x^{(n)} = x(x-1)\cdots(x-n+1)$ for $n$ a positive integer and let $x^{(0)} = 1.$ Prove that \[ (x+y)^{(n)} = \sum_{k=0}^n {n \choose k} x^{(k)} y^{(n-k)}. \]

--- a/lean4/src/putnam_1962_b2.lean
+++ b/lean4/src/putnam_1962_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory
 

--- a/lean4/src/putnam_1962_b3.lean
+++ b/lean4/src/putnam_1962_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory
 

--- a/lean4/src/putnam_1962_b5.lean
+++ b/lean4/src/putnam_1962_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory
 

--- a/lean4/src/putnam_1962_b6.lean
+++ b/lean4/src/putnam_1962_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Real
 

--- a/lean4/src/putnam_1963_a2.lean
+++ b/lean4/src/putnam_1963_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1963_a3.lean
+++ b/lean4/src/putnam_1963_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set Topology Filter
 

--- a/lean4/src/putnam_1963_a4.lean
+++ b/lean4/src/putnam_1963_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Set
 

--- a/lean4/src/putnam_1963_a6.lean
+++ b/lean4/src/putnam_1963_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1963_b1.lean
+++ b/lean4/src/putnam_1963_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial
 

--- a/lean4/src/putnam_1963_b2.lean
+++ b/lean4/src/putnam_1963_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial
 

--- a/lean4/src/putnam_1963_b3.lean
+++ b/lean4/src/putnam_1963_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial
 

--- a/lean4/src/putnam_1963_b5.lean
+++ b/lean4/src/putnam_1963_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial
 

--- a/lean4/src/putnam_1963_b6.lean
+++ b/lean4/src/putnam_1963_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial
 

--- a/lean4/src/putnam_1964_a1.lean
+++ b/lean4/src/putnam_1964_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $A_1, A_2, A_3, A_4, A_5, A_6$ be distinct points in the plane. Let $D$ be the longest distance between any pair, and let $d$ the shortest distance. Show that $\frac{D}{d} \geq \sqrt 3$.

--- a/lean4/src/putnam_1964_a2.lean
+++ b/lean4/src/putnam_1964_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1964_a3.lean
+++ b/lean4/src/putnam_1964_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function
 

--- a/lean4/src/putnam_1964_a4.lean
+++ b/lean4/src/putnam_1964_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function
 

--- a/lean4/src/putnam_1964_a5.lean
+++ b/lean4/src/putnam_1964_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1964_a6.lean
+++ b/lean4/src/putnam_1964_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1964_b1.lean
+++ b/lean4/src/putnam_1964_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1964_b2.lean
+++ b/lean4/src/putnam_1964_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1964_b3.lean
+++ b/lean4/src/putnam_1964_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1964_b5.lean
+++ b/lean4/src/putnam_1964_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1964_b6.lean
+++ b/lean4/src/putnam_1964_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology
 

--- a/lean4/src/putnam_1965_a1.lean
+++ b/lean4/src/putnam_1965_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Real
 

--- a/lean4/src/putnam_1965_a2.lean
+++ b/lean4/src/putnam_1965_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry
 

--- a/lean4/src/putnam_1965_a3.lean
+++ b/lean4/src/putnam_1965_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_a4.lean
+++ b/lean4/src/putnam_1965_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_a5.lean
+++ b/lean4/src/putnam_1965_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_a6.lean
+++ b/lean4/src/putnam_1965_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_b1.lean
+++ b/lean4/src/putnam_1965_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_b2.lean
+++ b/lean4/src/putnam_1965_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_b3.lean
+++ b/lean4/src/putnam_1965_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_b4.lean
+++ b/lean4/src/putnam_1965_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex
 

--- a/lean4/src/putnam_1965_b5.lean
+++ b/lean4/src/putnam_1965_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex SimpleGraph.Walk
 

--- a/lean4/src/putnam_1965_b6.lean
+++ b/lean4/src/putnam_1965_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Topology Filter Complex SimpleGraph.Walk
 

--- a/lean4/src/putnam_1966_a1.lean
+++ b/lean4/src/putnam_1966_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $a_n$ denote the sequence $0, 1, 1, 2, 2, 3, \dots$, where $a_n = \frac{n}{2}$ if $n$ is even and $\frac{n - 1}{2}$ if n is odd. Furthermore, let $f(n)$ denote the sum of the first $n$ terms of $a_n$. Prove that all positive integers $x$ and $y$ with $x > y$ satisfy $xy = f(x + y) - f(x - y)$.

--- a/lean4/src/putnam_1966_a2.lean
+++ b/lean4/src/putnam_1966_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $a$, $b$, and $c$ be the side lengths of a triangle with inradius $r$. If $p = \frac{a + b + c}{2}$, show that $$\frac{1}{(p - a)^2} + \frac{1}{(p - b)^2} + \frac{1}{(p - c)^2} \ge \frac{1}{r^2}.$$

--- a/lean4/src/putnam_1966_a3.lean
+++ b/lean4/src/putnam_1966_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_a4.lean
+++ b/lean4/src/putnam_1966_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_a5.lean
+++ b/lean4/src/putnam_1966_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_a6.lean
+++ b/lean4/src/putnam_1966_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_b1.lean
+++ b/lean4/src/putnam_1966_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology
 

--- a/lean4/src/putnam_1966_b2.lean
+++ b/lean4/src/putnam_1966_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Prove that, for any ten consecutive integers, at least one is relatively prime to all of the others.

--- a/lean4/src/putnam_1966_b3.lean
+++ b/lean4/src/putnam_1966_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_b4.lean
+++ b/lean4/src/putnam_1966_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_b5.lean
+++ b/lean4/src/putnam_1966_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1966_b6.lean
+++ b/lean4/src/putnam_1966_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1967_a1.lean
+++ b/lean4/src/putnam_1967_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_a2.lean
+++ b/lean4/src/putnam_1967_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_a3.lean
+++ b/lean4/src/putnam_1967_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_a4.lean
+++ b/lean4/src/putnam_1967_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_a5.lean
+++ b/lean4/src/putnam_1967_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_a6.lean
+++ b/lean4/src/putnam_1967_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_b1.lean
+++ b/lean4/src/putnam_1967_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_b2.lean
+++ b/lean4/src/putnam_1967_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_b3.lean
+++ b/lean4/src/putnam_1967_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_b4.lean
+++ b/lean4/src/putnam_1967_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_b5.lean
+++ b/lean4/src/putnam_1967_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1967_b6.lean
+++ b/lean4/src/putnam_1967_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_1968_a1.lean
+++ b/lean4/src/putnam_1968_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Prove that $$\frac{22}{7} - \pi = \int_{0}^{1} \frac{x^4(1 - x)^4}{1 + x^2} dx$$.

--- a/lean4/src/putnam_1968_a2.lean
+++ b/lean4/src/putnam_1968_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 For all integers $a$, $b$, $c$, $d$, $e$, and $f$ such that $ad \neq bc$ and any real number $\epsilon > 0$, prove that there exist rational numbers $r$ and $s$ such that $$0 < |ra + sb - e| < \varepsilon$$ and $$0 < |rc + sd - f| < \varepsilon.$$

--- a/lean4/src/putnam_1968_a3.lean
+++ b/lean4/src/putnam_1968_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset symmDiff
 

--- a/lean4/src/putnam_1968_a4.lean
+++ b/lean4/src/putnam_1968_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset
 

--- a/lean4/src/putnam_1968_a5.lean
+++ b/lean4/src/putnam_1968_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset Polynomial
 

--- a/lean4/src/putnam_1968_a6.lean
+++ b/lean4/src/putnam_1968_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset Polynomial
 

--- a/lean4/src/putnam_1968_b2.lean
+++ b/lean4/src/putnam_1968_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset Polynomial
 

--- a/lean4/src/putnam_1968_b4.lean
+++ b/lean4/src/putnam_1968_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset Polynomial Topology Filter Metric
 

--- a/lean4/src/putnam_1968_b5.lean
+++ b/lean4/src/putnam_1968_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset Polynomial Topology Filter Metric
 

--- a/lean4/src/putnam_1968_b6.lean
+++ b/lean4/src/putnam_1968_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Finset Polynomial Topology Filter Metric
 

--- a/lean4/src/putnam_1969_a1.lean
+++ b/lean4/src/putnam_1969_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_a2.lean
+++ b/lean4/src/putnam_1969_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_a4.lean
+++ b/lean4/src/putnam_1969_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_a5.lean
+++ b/lean4/src/putnam_1969_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_a6.lean
+++ b/lean4/src/putnam_1969_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_b1.lean
+++ b/lean4/src/putnam_1969_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_b2.lean
+++ b/lean4/src/putnam_1969_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_b3.lean
+++ b/lean4/src/putnam_1969_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_b5.lean
+++ b/lean4/src/putnam_1969_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1969_b6.lean
+++ b/lean4/src/putnam_1969_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Filter Topology Set Nat
 

--- a/lean4/src/putnam_1970_a1.lean
+++ b/lean4/src/putnam_1970_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry
 

--- a/lean4/src/putnam_1970_a2.lean
+++ b/lean4/src/putnam_1970_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry
 

--- a/lean4/src/putnam_1970_a3.lean
+++ b/lean4/src/putnam_1970_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry
 

--- a/lean4/src/putnam_1970_a4.lean
+++ b/lean4/src/putnam_1970_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1970_b1.lean
+++ b/lean4/src/putnam_1970_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1970_b2.lean
+++ b/lean4/src/putnam_1970_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1970_b3.lean
+++ b/lean4/src/putnam_1970_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1970_b4.lean
+++ b/lean4/src/putnam_1970_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1970_b5.lean
+++ b/lean4/src/putnam_1970_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1970_b6.lean
+++ b/lean4/src/putnam_1970_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric Set EuclideanGeometry Filter Topology
 

--- a/lean4/src/putnam_1971_a1.lean
+++ b/lean4/src/putnam_1971_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1971_a2.lean
+++ b/lean4/src/putnam_1971_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1971_a3.lean
+++ b/lean4/src/putnam_1971_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1971_a4.lean
+++ b/lean4/src/putnam_1971_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1971_a5.lean
+++ b/lean4/src/putnam_1971_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1971_a6.lean
+++ b/lean4/src/putnam_1971_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1971_b1.lean
+++ b/lean4/src/putnam_1971_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1971_b2.lean
+++ b/lean4/src/putnam_1971_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1971_b3.lean
+++ b/lean4/src/putnam_1971_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1971_b6.lean
+++ b/lean4/src/putnam_1971_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set MvPolynomial
 

--- a/lean4/src/putnam_1972_a1.lean
+++ b/lean4/src/putnam_1972_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set
 

--- a/lean4/src/putnam_1972_a2.lean
+++ b/lean4/src/putnam_1972_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set
 

--- a/lean4/src/putnam_1972_a3.lean
+++ b/lean4/src/putnam_1972_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set
 

--- a/lean4/src/putnam_1972_a5.lean
+++ b/lean4/src/putnam_1972_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set
 

--- a/lean4/src/putnam_1972_a6.lean
+++ b/lean4/src/putnam_1972_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set MeasureTheory
 

--- a/lean4/src/putnam_1972_b1.lean
+++ b/lean4/src/putnam_1972_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set MeasureTheory Metric
 

--- a/lean4/src/putnam_1972_b2.lean
+++ b/lean4/src/putnam_1972_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set MeasureTheory Metric
 

--- a/lean4/src/putnam_1972_b3.lean
+++ b/lean4/src/putnam_1972_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set MeasureTheory Metric
 

--- a/lean4/src/putnam_1972_b4.lean
+++ b/lean4/src/putnam_1972_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set MeasureTheory Metric
 

--- a/lean4/src/putnam_1972_b5.lean
+++ b/lean4/src/putnam_1972_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Set Metric
 

--- a/lean4/src/putnam_1972_b6.lean
+++ b/lean4/src/putnam_1972_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open EuclideanGeometry Filter Topology Set MeasureTheory Metric
 

--- a/lean4/src/putnam_1973_a1.lean
+++ b/lean4/src/putnam_1973_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_a2.lean
+++ b/lean4/src/putnam_1973_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_a3.lean
+++ b/lean4/src/putnam_1973_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_a4.lean
+++ b/lean4/src/putnam_1973_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_a6.lean
+++ b/lean4/src/putnam_1973_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_b1.lean
+++ b/lean4/src/putnam_1973_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_b2.lean
+++ b/lean4/src/putnam_1973_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_b3.lean
+++ b/lean4/src/putnam_1973_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1973_b4.lean
+++ b/lean4/src/putnam_1973_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set MeasureTheory Topology Filter
 

--- a/lean4/src/putnam_1974_a1.lean
+++ b/lean4/src/putnam_1974_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1974_a3.lean
+++ b/lean4/src/putnam_1974_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1974_a4.lean
+++ b/lean4/src/putnam_1974_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat
 

--- a/lean4/src/putnam_1974_a6.lean
+++ b/lean4/src/putnam_1974_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial
 

--- a/lean4/src/putnam_1974_b1.lean
+++ b/lean4/src/putnam_1974_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial
 

--- a/lean4/src/putnam_1974_b2.lean
+++ b/lean4/src/putnam_1974_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial Filter Topology
 

--- a/lean4/src/putnam_1974_b3.lean
+++ b/lean4/src/putnam_1974_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial Filter Topology
 

--- a/lean4/src/putnam_1974_b4.lean
+++ b/lean4/src/putnam_1974_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial Filter Topology
 

--- a/lean4/src/putnam_1974_b5.lean
+++ b/lean4/src/putnam_1974_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial Filter Topology
 

--- a/lean4/src/putnam_1974_b6.lean
+++ b/lean4/src/putnam_1974_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Polynomial Filter Topology
 

--- a/lean4/src/putnam_1975_a1.lean
+++ b/lean4/src/putnam_1975_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_1975_a2.lean
+++ b/lean4/src/putnam_1975_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_1975_a3.lean
+++ b/lean4/src/putnam_1975_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_1975_a4.lean
+++ b/lean4/src/putnam_1975_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex
 

--- a/lean4/src/putnam_1975_a5.lean
+++ b/lean4/src/putnam_1975_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex
 

--- a/lean4/src/putnam_1975_b1.lean
+++ b/lean4/src/putnam_1975_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex
 

--- a/lean4/src/putnam_1975_b2.lean
+++ b/lean4/src/putnam_1975_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex Matrix Filter Topology
 

--- a/lean4/src/putnam_1975_b3.lean
+++ b/lean4/src/putnam_1975_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex Matrix Filter Topology Multiset
 

--- a/lean4/src/putnam_1975_b4.lean
+++ b/lean4/src/putnam_1975_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex Matrix Filter Topology Multiset
 

--- a/lean4/src/putnam_1975_b5.lean
+++ b/lean4/src/putnam_1975_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex Matrix Filter Topology Multiset
 

--- a/lean4/src/putnam_1975_b6.lean
+++ b/lean4/src/putnam_1975_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Real Complex Matrix Filter Topology Multiset
 

--- a/lean4/src/putnam_1976_a2.lean
+++ b/lean4/src/putnam_1976_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial
 

--- a/lean4/src/putnam_1976_a3.lean
+++ b/lean4/src/putnam_1976_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1976_a3_solution : Set (ℕ × ℕ × ℕ × ℕ) := sorry
 -- {(3, 2, 2, 3), (2, 3, 3, 2)}

--- a/lean4/src/putnam_1976_a4.lean
+++ b/lean4/src/putnam_1976_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_1976_a6.lean
+++ b/lean4/src/putnam_1976_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_1976_b1.lean
+++ b/lean4/src/putnam_1976_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology
 

--- a/lean4/src/putnam_1976_b2.lean
+++ b/lean4/src/putnam_1976_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology
 

--- a/lean4/src/putnam_1976_b3.lean
+++ b/lean4/src/putnam_1976_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology ProbabilityTheory MeasureTheory
 

--- a/lean4/src/putnam_1976_b5.lean
+++ b/lean4/src/putnam_1976_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology ProbabilityTheory MeasureTheory
 

--- a/lean4/src/putnam_1976_b6.lean
+++ b/lean4/src/putnam_1976_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology ProbabilityTheory MeasureTheory
 

--- a/lean4/src/putnam_1977_a1.lean
+++ b/lean4/src/putnam_1977_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_1977_a1_solution : ℝ := sorry
 -- -7 / 8

--- a/lean4/src/putnam_1977_a2.lean
+++ b/lean4/src/putnam_1977_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1977_a2_solution : ℝ → ℝ → ℝ → ℝ → Prop := sorry
 -- fun a b c d ↦ d = a ∧ b = -c ∨ d = b ∧ a = -c ∨ d = c ∧ a = -b

--- a/lean4/src/putnam_1977_a3.lean
+++ b/lean4/src/putnam_1977_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1977_a3_solution : (ℝ → ℝ) → (ℝ → ℝ) → (ℝ → ℝ) := sorry
 -- fun f g x ↦ g x - f (x - 3) + f (x - 1) + f (x + 1) - f (x + 3)

--- a/lean4/src/putnam_1977_a4.lean
+++ b/lean4/src/putnam_1977_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set
 

--- a/lean4/src/putnam_1977_a5.lean
+++ b/lean4/src/putnam_1977_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set Nat
 

--- a/lean4/src/putnam_1977_a6.lean
+++ b/lean4/src/putnam_1977_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set Nat
 

--- a/lean4/src/putnam_1977_b1.lean
+++ b/lean4/src/putnam_1977_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set Nat Filter Topology
 

--- a/lean4/src/putnam_1977_b3.lean
+++ b/lean4/src/putnam_1977_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set Nat Filter Topology
 

--- a/lean4/src/putnam_1977_b5.lean
+++ b/lean4/src/putnam_1977_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set Nat Filter Topology
 

--- a/lean4/src/putnam_1977_b6.lean
+++ b/lean4/src/putnam_1977_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open RingHom Set Nat Filter Topology
 

--- a/lean4/src/putnam_1978_a1.lean
+++ b/lean4/src/putnam_1978_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $S = \{1, 4, 7, 10, 13, 16, \dots , 100\}$. Let $T$ be a subset of $20$ elements of $S$. Show that we can find two distinct elements of $T$ with sum $104$.

--- a/lean4/src/putnam_1978_a2.lean
+++ b/lean4/src/putnam_1978_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $A$ be the real $n \times n$ matrix $(a_{ij})$ where $a_{ij} = a$ for $i < j$, $b \; (\neq a)$ for $i > j$, and $c_i$ for $i = j$. Show that $\det A = \frac{b p(a) - a p(b)}{b - a}$, where $p(x) = \prod_{i=1}^n (c_i - x)$.

--- a/lean4/src/putnam_1978_a3.lean
+++ b/lean4/src/putnam_1978_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Polynomial
 

--- a/lean4/src/putnam_1978_a4.lean
+++ b/lean4/src/putnam_1978_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1978_a5.lean
+++ b/lean4/src/putnam_1978_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real
 

--- a/lean4/src/putnam_1978_a6.lean
+++ b/lean4/src/putnam_1978_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real
 

--- a/lean4/src/putnam_1978_b2.lean
+++ b/lean4/src/putnam_1978_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real
 

--- a/lean4/src/putnam_1978_b3.lean
+++ b/lean4/src/putnam_1978_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real Filter Topology Polynomial
 

--- a/lean4/src/putnam_1978_b4.lean
+++ b/lean4/src/putnam_1978_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real Filter Topology Polynomial
 

--- a/lean4/src/putnam_1978_b5.lean
+++ b/lean4/src/putnam_1978_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real Filter Topology Polynomial
 

--- a/lean4/src/putnam_1978_b6.lean
+++ b/lean4/src/putnam_1978_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Real Filter Topology Polynomial
 

--- a/lean4/src/putnam_1979_a1.lean
+++ b/lean4/src/putnam_1979_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1979_a1_solution : Multiset ℕ := sorry
 -- Multiset.replicate 659 3 + {2}

--- a/lean4/src/putnam_1979_a2.lean
+++ b/lean4/src/putnam_1979_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1979_a2_solution : ℝ → Prop := sorry
 -- fun k : ℝ => k ≥ 0

--- a/lean4/src/putnam_1979_a3.lean
+++ b/lean4/src/putnam_1979_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1979_a3_solution : (ℝ × ℝ) → Prop := sorry
 -- fun (a, b) => ∃ m : ℤ, a = m ∧ b = m

--- a/lean4/src/putnam_1979_a4.lean
+++ b/lean4/src/putnam_1979_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1979_a5.lean
+++ b/lean4/src/putnam_1979_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1979_a6.lean
+++ b/lean4/src/putnam_1979_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1979_b2.lean
+++ b/lean4/src/putnam_1979_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Topology Filter
 

--- a/lean4/src/putnam_1979_b3.lean
+++ b/lean4/src/putnam_1979_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Topology Filter Polynomial
 

--- a/lean4/src/putnam_1979_b5.lean
+++ b/lean4/src/putnam_1979_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Topology Filter Polynomial MeasureTheory
 

--- a/lean4/src/putnam_1979_b6.lean
+++ b/lean4/src/putnam_1979_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Topology Filter Polynomial MeasureTheory
 

--- a/lean4/src/putnam_1980_a2.lean
+++ b/lean4/src/putnam_1980_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1980_a2_solution : ℕ → ℕ → ℕ := sorry
 -- (fun r s : ℕ => (1 + 4 * r + 6 * r ^ 2) * (1 + 4 * s + 6 * s ^ 2))

--- a/lean4/src/putnam_1980_a3.lean
+++ b/lean4/src/putnam_1980_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_1980_a3_solution : ℝ := sorry
 -- Real.pi / 4

--- a/lean4/src/putnam_1980_a4.lean
+++ b/lean4/src/putnam_1980_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 \begin{enumerate}

--- a/lean4/src/putnam_1980_a5.lean
+++ b/lean4/src/putnam_1980_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $P(t)$ be a nonconstant polynomial with real coefficients. Prove that the system of simultaneous equations $0=\int_0^xP(t)\sin t\,dt=\int_0^xP(t)\cos t\,dt$ has only finitely many real solutions $x$.

--- a/lean4/src/putnam_1980_a6.lean
+++ b/lean4/src/putnam_1980_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: uses (ℝ → ℝ) instead of (Set.Icc (0 : ℝ) 1 → ℝ)
 noncomputable abbrev putnam_1980_a6_solution : ℝ := sorry

--- a/lean4/src/putnam_1980_b1.lean
+++ b/lean4/src/putnam_1980_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Real
 

--- a/lean4/src/putnam_1980_b3.lean
+++ b/lean4/src/putnam_1980_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1980_b3_solution : Set ℝ := sorry
 -- {a : ℝ | a ≥ 3}

--- a/lean4/src/putnam_1980_b4.lean
+++ b/lean4/src/putnam_1980_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $X$ be a finite set with at least $10$ elements; for each $i \in \{0, 1, ..., 1065\}$, let $A_i \subseteq X$ satisfy $|A_i| > \frac{1}{2}|X|$. Prove that there exist $10$ elements $x_1, x_2, \dots, x_{10} \in X$ such that each $A_i$ contains at least one of $x_1, x_2, \dots, x_{10}$.

--- a/lean4/src/putnam_1980_b5.lean
+++ b/lean4/src/putnam_1980_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1980_b6.lean
+++ b/lean4/src/putnam_1980_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1981_a1.lean
+++ b/lean4/src/putnam_1981_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_a3.lean
+++ b/lean4/src/putnam_1981_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_a5.lean
+++ b/lean4/src/putnam_1981_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_b1.lean
+++ b/lean4/src/putnam_1981_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_b2.lean
+++ b/lean4/src/putnam_1981_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_b3.lean
+++ b/lean4/src/putnam_1981_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_b4.lean
+++ b/lean4/src/putnam_1981_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1981_b5.lean
+++ b/lean4/src/putnam_1981_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Polynomial Function
 

--- a/lean4/src/putnam_1982_a2.lean
+++ b/lean4/src/putnam_1982_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1982_a3.lean
+++ b/lean4/src/putnam_1982_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1982_a4.lean
+++ b/lean4/src/putnam_1982_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Filter Topology
 

--- a/lean4/src/putnam_1982_a5.lean
+++ b/lean4/src/putnam_1982_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $a, b, c, d$ be positive integers satisfying $a + c \leq 1982$ and $\frac{a}{b} + \frac{c}{d} < 1$. Prove that $1 - \frac{a}{b} - \frac{c}{d} > \frac{1}{1983^3}$.

--- a/lean4/src/putnam_1982_a6.lean
+++ b/lean4/src/putnam_1982_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1982_b2.lean
+++ b/lean4/src/putnam_1982_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1982_b3.lean
+++ b/lean4/src/putnam_1982_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1982_b4.lean
+++ b/lean4/src/putnam_1982_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1982_b5.lean
+++ b/lean4/src/putnam_1982_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Filter Topology Polynomial Real
 

--- a/lean4/src/putnam_1983_a1.lean
+++ b/lean4/src/putnam_1983_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1983_a1_solution : ℕ := sorry
 -- 2301

--- a/lean4/src/putnam_1983_a3.lean
+++ b/lean4/src/putnam_1983_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $p$ be in the set $\{3,5,7,11,\dots\}$ of odd primes and let $F(n)=1+2n+3n^2+\dots+(p-1)n^{p-2}$. Prove that if $a$ and $b$ are distinct integers in $\{0,1,2,\dots,p-1\}$ then $F(a)$ and $F(b)$ are not congruent modulo $p$, that is, $F(a)-F(b)$ is not exactly divisible by $p$.

--- a/lean4/src/putnam_1983_a4.lean
+++ b/lean4/src/putnam_1983_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_1983_a5.lean
+++ b/lean4/src/putnam_1983_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_1983_a6.lean
+++ b/lean4/src/putnam_1983_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology Real
 

--- a/lean4/src/putnam_1983_b2.lean
+++ b/lean4/src/putnam_1983_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology Real
 

--- a/lean4/src/putnam_1983_b4.lean
+++ b/lean4/src/putnam_1983_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Real
 

--- a/lean4/src/putnam_1983_b5.lean
+++ b/lean4/src/putnam_1983_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology Real
 

--- a/lean4/src/putnam_1983_b6.lean
+++ b/lean4/src/putnam_1983_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology Real Polynomial
 

--- a/lean4/src/putnam_1984_a2.lean
+++ b/lean4/src/putnam_1984_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1984_a2_solution : ℚ := sorry
 -- 2

--- a/lean4/src/putnam_1984_a3.lean
+++ b/lean4/src/putnam_1984_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1984_a5.lean
+++ b/lean4/src/putnam_1984_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_1984_a6.lean
+++ b/lean4/src/putnam_1984_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Function Nat
 

--- a/lean4/src/putnam_1984_b1.lean
+++ b/lean4/src/putnam_1984_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_1984_b2.lean
+++ b/lean4/src/putnam_1984_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_1984_b3.lean
+++ b/lean4/src/putnam_1984_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_1984_b5.lean
+++ b/lean4/src/putnam_1984_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_1985_a1.lean
+++ b/lean4/src/putnam_1985_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1985_a3.lean
+++ b/lean4/src/putnam_1985_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real
 

--- a/lean4/src/putnam_1985_a4.lean
+++ b/lean4/src/putnam_1985_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real
 

--- a/lean4/src/putnam_1985_a5.lean
+++ b/lean4/src/putnam_1985_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real
 

--- a/lean4/src/putnam_1985_a6.lean
+++ b/lean4/src/putnam_1985_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real Polynomial
 

--- a/lean4/src/putnam_1985_b1.lean
+++ b/lean4/src/putnam_1985_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real Polynomial Function
 

--- a/lean4/src/putnam_1985_b2.lean
+++ b/lean4/src/putnam_1985_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real Polynomial Function
 

--- a/lean4/src/putnam_1985_b3.lean
+++ b/lean4/src/putnam_1985_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real Polynomial Function
 

--- a/lean4/src/putnam_1985_b5.lean
+++ b/lean4/src/putnam_1985_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real Polynomial Function
 

--- a/lean4/src/putnam_1985_b6.lean
+++ b/lean4/src/putnam_1985_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology Real Polynomial Function
 

--- a/lean4/src/putnam_1986_a1.lean
+++ b/lean4/src/putnam_1986_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1986_a1_solution : ℝ := sorry
 -- 18

--- a/lean4/src/putnam_1986_a2.lean
+++ b/lean4/src/putnam_1986_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1986_a2_solution : ℕ := sorry
 -- 3

--- a/lean4/src/putnam_1986_a3.lean
+++ b/lean4/src/putnam_1986_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real
 

--- a/lean4/src/putnam_1986_a4.lean
+++ b/lean4/src/putnam_1986_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv
 

--- a/lean4/src/putnam_1986_a5.lean
+++ b/lean4/src/putnam_1986_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv
 

--- a/lean4/src/putnam_1986_a6.lean
+++ b/lean4/src/putnam_1986_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv
 

--- a/lean4/src/putnam_1986_b1.lean
+++ b/lean4/src/putnam_1986_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv
 

--- a/lean4/src/putnam_1986_b2.lean
+++ b/lean4/src/putnam_1986_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv
 

--- a/lean4/src/putnam_1986_b3.lean
+++ b/lean4/src/putnam_1986_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv Polynomial
 

--- a/lean4/src/putnam_1986_b4.lean
+++ b/lean4/src/putnam_1986_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv Polynomial Filter Topology
 

--- a/lean4/src/putnam_1986_b5.lean
+++ b/lean4/src/putnam_1986_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv Polynomial Filter Topology MvPolynomial
 

--- a/lean4/src/putnam_1986_b6.lean
+++ b/lean4/src/putnam_1986_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open  Real Equiv Polynomial Filter Topology MvPolynomial Matrix
 

--- a/lean4/src/putnam_1987_a1.lean
+++ b/lean4/src/putnam_1987_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Curves $A$, $B$, $C$, and $D$ are defined in the plane as follows:

--- a/lean4/src/putnam_1987_a2.lean
+++ b/lean4/src/putnam_1987_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1987_a2_solution : ℕ := sorry
 -- 1984

--- a/lean4/src/putnam_1987_a4.lean
+++ b/lean4/src/putnam_1987_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real
 

--- a/lean4/src/putnam_1987_a5.lean
+++ b/lean4/src/putnam_1987_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real
 

--- a/lean4/src/putnam_1987_a6.lean
+++ b/lean4/src/putnam_1987_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat
 

--- a/lean4/src/putnam_1987_b1.lean
+++ b/lean4/src/putnam_1987_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat
 

--- a/lean4/src/putnam_1987_b2.lean
+++ b/lean4/src/putnam_1987_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat
 

--- a/lean4/src/putnam_1987_b3.lean
+++ b/lean4/src/putnam_1987_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat
 

--- a/lean4/src/putnam_1987_b4.lean
+++ b/lean4/src/putnam_1987_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat Filter Topology
 

--- a/lean4/src/putnam_1987_b5.lean
+++ b/lean4/src/putnam_1987_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat Filter Topology
 

--- a/lean4/src/putnam_1987_b6.lean
+++ b/lean4/src/putnam_1987_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Real Nat Filter Topology
 

--- a/lean4/src/putnam_1988_a1.lean
+++ b/lean4/src/putnam_1988_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1988_a1_solution : ℝ := sorry
 -- 6

--- a/lean4/src/putnam_1988_a2.lean
+++ b/lean4/src/putnam_1988_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_1988_a3.lean
+++ b/lean4/src/putnam_1988_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_a4.lean
+++ b/lean4/src/putnam_1988_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_a5.lean
+++ b/lean4/src/putnam_1988_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_a6.lean
+++ b/lean4/src/putnam_1988_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_b1.lean
+++ b/lean4/src/putnam_1988_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_b2.lean
+++ b/lean4/src/putnam_1988_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_b3.lean
+++ b/lean4/src/putnam_1988_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_b4.lean
+++ b/lean4/src/putnam_1988_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_b5.lean
+++ b/lean4/src/putnam_1988_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1988_b6.lean
+++ b/lean4/src/putnam_1988_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Filter Topology
 

--- a/lean4/src/putnam_1989_a1.lean
+++ b/lean4/src/putnam_1989_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1989_a1_solution : ℕ∞ := sorry
 -- 1

--- a/lean4/src/putnam_1989_a2.lean
+++ b/lean4/src/putnam_1989_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_1989_a2_solution : ℝ → ℝ → ℝ := sorry
 -- (fun a b : ℝ => (Real.exp (a ^ 2 * b ^ 2) - 1) / (a * b))

--- a/lean4/src/putnam_1989_a3.lean
+++ b/lean4/src/putnam_1989_a3.lean
@@ -1,5 +1,5 @@
 import Mathlib
-open BigOperators Complex
+open Complex
 
 /--
 Prove that if

--- a/lean4/src/putnam_1989_a6.lean
+++ b/lean4/src/putnam_1989_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_1989_b1.lean
+++ b/lean4/src/putnam_1989_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_1989_b2.lean
+++ b/lean4/src/putnam_1989_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_1989_b3.lean
+++ b/lean4/src/putnam_1989_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology
 

--- a/lean4/src/putnam_1989_b4.lean
+++ b/lean4/src/putnam_1989_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology Set
 

--- a/lean4/src/putnam_1989_b6.lean
+++ b/lean4/src/putnam_1989_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Filter Topology Set
 

--- a/lean4/src/putnam_1990_a1.lean
+++ b/lean4/src/putnam_1990_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_a2.lean
+++ b/lean4/src/putnam_1990_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_a4.lean
+++ b/lean4/src/putnam_1990_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_a5.lean
+++ b/lean4/src/putnam_1990_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_a6.lean
+++ b/lean4/src/putnam_1990_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_b1.lean
+++ b/lean4/src/putnam_1990_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_b2.lean
+++ b/lean4/src/putnam_1990_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_b3.lean
+++ b/lean4/src/putnam_1990_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_b4.lean
+++ b/lean4/src/putnam_1990_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Nat
 

--- a/lean4/src/putnam_1990_b5.lean
+++ b/lean4/src/putnam_1990_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Polynomial Topology Nat
 

--- a/lean4/src/putnam_1991_a2.lean
+++ b/lean4/src/putnam_1991_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_a3.lean
+++ b/lean4/src/putnam_1991_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_a4.lean
+++ b/lean4/src/putnam_1991_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter FiniteDimensional Metric Topology
 

--- a/lean4/src/putnam_1991_a5.lean
+++ b/lean4/src/putnam_1991_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_a6.lean
+++ b/lean4/src/putnam_1991_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_b1.lean
+++ b/lean4/src/putnam_1991_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_b2.lean
+++ b/lean4/src/putnam_1991_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_b4.lean
+++ b/lean4/src/putnam_1991_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_b5.lean
+++ b/lean4/src/putnam_1991_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1991_b6.lean
+++ b/lean4/src/putnam_1991_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1992_a1.lean
+++ b/lean4/src/putnam_1992_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1992_a2.lean
+++ b/lean4/src/putnam_1992_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_1992_a3.lean
+++ b/lean4/src/putnam_1992_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_1992_a4.lean
+++ b/lean4/src/putnam_1992_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function
 

--- a/lean4/src/putnam_1992_a5.lean
+++ b/lean4/src/putnam_1992_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function
 

--- a/lean4/src/putnam_1992_b1.lean
+++ b/lean4/src/putnam_1992_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function
 

--- a/lean4/src/putnam_1992_b2.lean
+++ b/lean4/src/putnam_1992_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function Polynomial
 

--- a/lean4/src/putnam_1992_b3.lean
+++ b/lean4/src/putnam_1992_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function Polynomial
 

--- a/lean4/src/putnam_1992_b4.lean
+++ b/lean4/src/putnam_1992_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function Polynomial
 

--- a/lean4/src/putnam_1992_b5.lean
+++ b/lean4/src/putnam_1992_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function Polynomial
 

--- a/lean4/src/putnam_1992_b6.lean
+++ b/lean4/src/putnam_1992_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Function Polynomial
 

--- a/lean4/src/putnam_1993_a1.lean
+++ b/lean4/src/putnam_1993_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_1993_a1_solution : ℝ := sorry
 -- 4 / 9

--- a/lean4/src/putnam_1993_a2.lean
+++ b/lean4/src/putnam_1993_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $(x_n)_{n \geq 0}$ be a sequence of nonzero real numbers such that $x_n^2-x_{n-1}x_{n+1}=1$ for $n=1,2,3,\dots$. Prove there exists a real number $a$ such that $x_{n+1}=ax_n-x_{n-1}$ for all $n \geq 1$.

--- a/lean4/src/putnam_1993_a3.lean
+++ b/lean4/src/putnam_1993_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $\mathcal{P}_n$ be the set of subsets of $\{1,2,\dots,n\}$. Let $c(n,m)$ be the number of functions $f:\mathcal{P}_n \to \{1,2,\dots,m\}$ such that $f(A \cap B)=\min\{f(A),f(B)\}$. Prove that $c(n,m)=\sum_{j=1}^m j^n$.

--- a/lean4/src/putnam_1993_a4.lean
+++ b/lean4/src/putnam_1993_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $x_1,x_2,\dots,x_{19}$ be positive integers each of which is less than or equal to $93$. Let $y_1,y_2,\dots,y_{93}$ be positive integers each of which is less than or equal to $19$. Prove that there exists a (nonempty) sum of some $x_i$'s equal to a sum of some $y_j$'s.

--- a/lean4/src/putnam_1993_a5.lean
+++ b/lean4/src/putnam_1993_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Show that $\int_{-100}^{-10} (\frac{x^2-x}{x^3-3x+1})^2\,dx+\int_{\frac{1}{101}}^{\frac{1}{11}} (\frac{x^2-x}{x^3-3x+1})^2\,dx+\int_{\frac{101}{100}}^{\frac{11}{10}} (\frac{x^2-x}{x^3-3x+1})^2\,dx$ is a rational number.

--- a/lean4/src/putnam_1993_a6.lean
+++ b/lean4/src/putnam_1993_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 The infinite sequence of $2$'s and $3$'s $2,3,3,2,3,3,3,2,3,3,3,2,3,3,2,3,3,3,2,3,3,3,2,3,3,3,2,3,3,2,3,3,3,2,\dots$ has the property that, if one forms a second sequence that records the number of $3$'s between successive $2$'s, the result is identical to the given sequence. Show that there exists a real number $r$ such that, for any $n$, the $n$th term of the sequence is $2$ if and only if $n=1+\lfloor rm \rfloor$ for some nonnegative integer $m$. (Note: $\lfloor x \rfloor$ denotes the largest integer less than or equal to $x$.)

--- a/lean4/src/putnam_1993_b1.lean
+++ b/lean4/src/putnam_1993_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1993_b1_solution : ℕ := sorry
 -- 3987

--- a/lean4/src/putnam_1993_b3.lean
+++ b/lean4/src/putnam_1993_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1993_b3_solution : ℚ × ℚ := sorry
 -- (5 / 4, -1 / 4)

--- a/lean4/src/putnam_1993_b4.lean
+++ b/lean4/src/putnam_1993_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 The function $K(x,y)$ is positive and continuous for $0 \leq x \leq 1,0 \leq y \leq 1$, and the functions $f(x)$ and $g(x)$ are positive and continuous for $0 \leq x \leq 1$. Suppose that for all $x$, $0 \leq x \leq 1$, $\int_0^1 f(y)K(x,y)\,dy=g(x)$ and $\int_0^1 g(y)K(x,y)\,dy=f(x)$. Show that $f(x)=g(x)$ for $0 \leq x \leq 1$.

--- a/lean4/src/putnam_1993_b5.lean
+++ b/lean4/src/putnam_1993_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Show there do not exist four points in the Euclidean plane such that the pairwise distances between the points are all odd integers.

--- a/lean4/src/putnam_1993_b6.lean
+++ b/lean4/src/putnam_1993_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: uses (ℕ → (Fin 3 → ℕ)) instead of (Fin (N + 1) → (Fin 3 → ℕ))
 /--

--- a/lean4/src/putnam_1994_a1.lean
+++ b/lean4/src/putnam_1994_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_a3.lean
+++ b/lean4/src/putnam_1994_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_a4.lean
+++ b/lean4/src/putnam_1994_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_a5.lean
+++ b/lean4/src/putnam_1994_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_a6.lean
+++ b/lean4/src/putnam_1994_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Classical Filter Topology
 

--- a/lean4/src/putnam_1994_b1.lean
+++ b/lean4/src/putnam_1994_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_b2.lean
+++ b/lean4/src/putnam_1994_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_b3.lean
+++ b/lean4/src/putnam_1994_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_b4.lean
+++ b/lean4/src/putnam_1994_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_b5.lean
+++ b/lean4/src/putnam_1994_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1994_b6.lean
+++ b/lean4/src/putnam_1994_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1995_a1.lean
+++ b/lean4/src/putnam_1995_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $S$ be a set of real numbers which is closed under multiplication (that is, if $a$ and $b$ are in $S$, then so is $ab$). Let $T$ and $U$ be disjoint subsets of $S$ whose union is $S$. Given that the product of any {\em three} (not necessarily distinct) elements of $T$ is in $T$ and that the product of any three elements of $U$ is in $U$, show that at least one of the two subsets $T,U$ is closed under multiplication.

--- a/lean4/src/putnam_1995_a2.lean
+++ b/lean4/src/putnam_1995_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real
 

--- a/lean4/src/putnam_1995_a3.lean
+++ b/lean4/src/putnam_1995_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real
 

--- a/lean4/src/putnam_1995_a4.lean
+++ b/lean4/src/putnam_1995_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real
 

--- a/lean4/src/putnam_1995_a5.lean
+++ b/lean4/src/putnam_1995_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real
 

--- a/lean4/src/putnam_1995_a6.lean
+++ b/lean4/src/putnam_1995_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real
 

--- a/lean4/src/putnam_1995_b1.lean
+++ b/lean4/src/putnam_1995_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real Nat
 

--- a/lean4/src/putnam_1995_b3.lean
+++ b/lean4/src/putnam_1995_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real Nat
 

--- a/lean4/src/putnam_1995_b4.lean
+++ b/lean4/src/putnam_1995_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real Nat
 

--- a/lean4/src/putnam_1995_b6.lean
+++ b/lean4/src/putnam_1995_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Real Nat
 

--- a/lean4/src/putnam_1996_a2.lean
+++ b/lean4/src/putnam_1996_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Metric
 

--- a/lean4/src/putnam_1996_a3.lean
+++ b/lean4/src/putnam_1996_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_1996_a3_solution : Prop := sorry
 -- False

--- a/lean4/src/putnam_1996_a4.lean
+++ b/lean4/src/putnam_1996_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_1996_a5.lean
+++ b/lean4/src/putnam_1996_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_1996_a6.lean
+++ b/lean4/src/putnam_1996_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_1996_b1.lean
+++ b/lean4/src/putnam_1996_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_1996_b2.lean
+++ b/lean4/src/putnam_1996_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_1996_b3.lean
+++ b/lean4/src/putnam_1996_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_1996_b4.lean
+++ b/lean4/src/putnam_1996_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Nat
 

--- a/lean4/src/putnam_1996_b5.lean
+++ b/lean4/src/putnam_1996_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Nat
 

--- a/lean4/src/putnam_1997_a3.lean
+++ b/lean4/src/putnam_1997_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1997_a4.lean
+++ b/lean4/src/putnam_1997_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1997_a5.lean
+++ b/lean4/src/putnam_1997_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1997_a6.lean
+++ b/lean4/src/putnam_1997_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1997_b1.lean
+++ b/lean4/src/putnam_1997_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_1997_b2.lean
+++ b/lean4/src/putnam_1997_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Bornology Set
 

--- a/lean4/src/putnam_1997_b3.lean
+++ b/lean4/src/putnam_1997_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Bornology Set
 

--- a/lean4/src/putnam_1997_b4.lean
+++ b/lean4/src/putnam_1997_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Bornology Set Polynomial
 

--- a/lean4/src/putnam_1997_b5.lean
+++ b/lean4/src/putnam_1997_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 def tetration : ℕ → ℕ → ℕ
   | _, 0 => 1

--- a/lean4/src/putnam_1998_a2.lean
+++ b/lean4/src/putnam_1998_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $s$ be any arc of the unit circle lying entirely in the first quadrant. Let $A$ be the area of the region lying below $s$ and above the $x$-axis and let $B$ be the area of the region lying to the right of the $y$-axis and to the left of $s$. Prove that $A+B$ depends only on the arc length, and not on the position, of $s$.

--- a/lean4/src/putnam_1998_a3.lean
+++ b/lean4/src/putnam_1998_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $f$ be a real function on the real line with continuous third derivative.  Prove that there exists a point $a$ such that \[f(a)\cdot f'(a) \cdot f''(a) \cdot f'''(a)\geq 0 .\]

--- a/lean4/src/putnam_1998_a4.lean
+++ b/lean4/src/putnam_1998_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: Since 11 divides `x` iff it divides its base-10 reverse, the `reverse` below is optional.
 abbrev putnam_1998_a4_solution : Set ℕ := sorry

--- a/lean4/src/putnam_1998_a5.lean
+++ b/lean4/src/putnam_1998_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1998_a6.lean
+++ b/lean4/src/putnam_1998_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1998_b1.lean
+++ b/lean4/src/putnam_1998_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1998_b2.lean
+++ b/lean4/src/putnam_1998_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1998_b4.lean
+++ b/lean4/src/putnam_1998_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1998_b5.lean
+++ b/lean4/src/putnam_1998_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1998_b6.lean
+++ b/lean4/src/putnam_1998_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Function Metric
 

--- a/lean4/src/putnam_1999_a1.lean
+++ b/lean4/src/putnam_1999_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: The actual problem asks to "find" such polynomials as well - but the solution does not give a set of all possible solutions. Hence, we would need to do the analysis ourselves, the following formalization should work.
 abbrev putnam_1999_a1_solution : Prop := sorry

--- a/lean4/src/putnam_1999_a2.lean
+++ b/lean4/src/putnam_1999_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $p(x)$ be a polynomial that is nonnegative for all real $x$.  Prove that for some $k$, there are polynomials $f_1(x),\dots,f_k(x$) such that \[p(x) =  \sum_{j=1}^k (f_j(x))^2.\]

--- a/lean4/src/putnam_1999_a3.lean
+++ b/lean4/src/putnam_1999_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_a4.lean
+++ b/lean4/src/putnam_1999_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_a5.lean
+++ b/lean4/src/putnam_1999_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_a6.lean
+++ b/lean4/src/putnam_1999_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_b2.lean
+++ b/lean4/src/putnam_1999_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_b3.lean
+++ b/lean4/src/putnam_1999_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_b4.lean
+++ b/lean4/src/putnam_1999_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_b5.lean
+++ b/lean4/src/putnam_1999_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_1999_b6.lean
+++ b/lean4/src/putnam_1999_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_2000_a1.lean
+++ b/lean4/src/putnam_2000_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2000_a2.lean
+++ b/lean4/src/putnam_2000_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2000_a4.lean
+++ b/lean4/src/putnam_2000_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2000_a5.lean
+++ b/lean4/src/putnam_2000_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2000_a6.lean
+++ b/lean4/src/putnam_2000_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2000_b1.lean
+++ b/lean4/src/putnam_2000_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2000_b2.lean
+++ b/lean4/src/putnam_2000_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2000_b3.lean
+++ b/lean4/src/putnam_2000_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Set Function
 

--- a/lean4/src/putnam_2000_b4.lean
+++ b/lean4/src/putnam_2000_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Set Function
 

--- a/lean4/src/putnam_2000_b5.lean
+++ b/lean4/src/putnam_2000_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Set Function
 

--- a/lean4/src/putnam_2001_a1.lean
+++ b/lean4/src/putnam_2001_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2001_a3.lean
+++ b/lean4/src/putnam_2001_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_a5.lean
+++ b/lean4/src/putnam_2001_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_b1.lean
+++ b/lean4/src/putnam_2001_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_b2.lean
+++ b/lean4/src/putnam_2001_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_b3.lean
+++ b/lean4/src/putnam_2001_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_b4.lean
+++ b/lean4/src/putnam_2001_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_b5.lean
+++ b/lean4/src/putnam_2001_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2001_b6.lean
+++ b/lean4/src/putnam_2001_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Polynomial Set
 

--- a/lean4/src/putnam_2002_a1.lean
+++ b/lean4/src/putnam_2002_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2002_a2.lean
+++ b/lean4/src/putnam_2002_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Metric
 

--- a/lean4/src/putnam_2002_a3.lean
+++ b/lean4/src/putnam_2002_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2002_a5.lean
+++ b/lean4/src/putnam_2002_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2002_a6.lean
+++ b/lean4/src/putnam_2002_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set Topology Filter
 

--- a/lean4/src/putnam_2002_b3.lean
+++ b/lean4/src/putnam_2002_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set Topology Filter
 

--- a/lean4/src/putnam_2002_b5.lean
+++ b/lean4/src/putnam_2002_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set Topology Filter
 

--- a/lean4/src/putnam_2002_b6.lean
+++ b/lean4/src/putnam_2002_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set Topology Filter Matrix MvPolynomial
 

--- a/lean4/src/putnam_2003_a1.lean
+++ b/lean4/src/putnam_2003_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial
 

--- a/lean4/src/putnam_2003_a2.lean
+++ b/lean4/src/putnam_2003_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial
 

--- a/lean4/src/putnam_2003_a3.lean
+++ b/lean4/src/putnam_2003_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial
 

--- a/lean4/src/putnam_2003_a4.lean
+++ b/lean4/src/putnam_2003_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial
 

--- a/lean4/src/putnam_2003_a5.lean
+++ b/lean4/src/putnam_2003_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set
 

--- a/lean4/src/putnam_2003_a6.lean
+++ b/lean4/src/putnam_2003_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set
 

--- a/lean4/src/putnam_2003_b1.lean
+++ b/lean4/src/putnam_2003_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set
 

--- a/lean4/src/putnam_2003_b2.lean
+++ b/lean4/src/putnam_2003_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set
 

--- a/lean4/src/putnam_2003_b3.lean
+++ b/lean4/src/putnam_2003_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set Nat
 

--- a/lean4/src/putnam_2003_b4.lean
+++ b/lean4/src/putnam_2003_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set Nat
 

--- a/lean4/src/putnam_2003_b5.lean
+++ b/lean4/src/putnam_2003_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set Nat
 

--- a/lean4/src/putnam_2003_b6.lean
+++ b/lean4/src/putnam_2003_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MvPolynomial Set Nat
 

--- a/lean4/src/putnam_2004_a1.lean
+++ b/lean4/src/putnam_2004_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_a3.lean
+++ b/lean4/src/putnam_2004_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_a4.lean
+++ b/lean4/src/putnam_2004_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_a5.lean
+++ b/lean4/src/putnam_2004_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_a6.lean
+++ b/lean4/src/putnam_2004_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_b1.lean
+++ b/lean4/src/putnam_2004_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_b2.lean
+++ b/lean4/src/putnam_2004_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_b4.lean
+++ b/lean4/src/putnam_2004_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_b5.lean
+++ b/lean4/src/putnam_2004_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2004_b6.lean
+++ b/lean4/src/putnam_2004_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2005_a1.lean
+++ b/lean4/src/putnam_2005_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2005_a2.lean
+++ b/lean4/src/putnam_2005_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_a3.lean
+++ b/lean4/src/putnam_2005_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_a4.lean
+++ b/lean4/src/putnam_2005_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_a5.lean
+++ b/lean4/src/putnam_2005_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_b1.lean
+++ b/lean4/src/putnam_2005_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_b2.lean
+++ b/lean4/src/putnam_2005_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_b3.lean
+++ b/lean4/src/putnam_2005_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_b4.lean
+++ b/lean4/src/putnam_2005_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_b5.lean
+++ b/lean4/src/putnam_2005_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2005_b6.lean
+++ b/lean4/src/putnam_2005_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Set
 

--- a/lean4/src/putnam_2006_a1.lean
+++ b/lean4/src/putnam_2006_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2006_a1_solution : ℝ := sorry
 -- 6 * Real.pi ^ 2

--- a/lean4/src/putnam_2006_a3.lean
+++ b/lean4/src/putnam_2006_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $1, 2, 3, \dots, 2005, 2006, 2007, 2009, 2012, 2016, \dots$ be a sequence defined by $x_k = k$ for $k=1, 2, \dots, 2006$ and $x_{k+1} = x_k + x_{k-2005}$ for $k \geq 2006$. Show that the sequence has $2005$ consecutive terms each divisible by $2006$.

--- a/lean4/src/putnam_2006_a4.lean
+++ b/lean4/src/putnam_2006_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: uses (ℕ → ℕ) instead of (Equiv.Perm (Fin n))
 noncomputable abbrev putnam_2006_a4_solution : ℕ → ℝ := sorry

--- a/lean4/src/putnam_2006_a5.lean
+++ b/lean4/src/putnam_2006_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2006_a5_solution : ℕ → ℤ := sorry
 -- (fun n : ℕ => if (n ≡ 1 [MOD 4]) then n else -n)

--- a/lean4/src/putnam_2006_b1.lean
+++ b/lean4/src/putnam_2006_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2006_b1_solution : ℝ := sorry
 -- 3 * Real.sqrt 3 / 2

--- a/lean4/src/putnam_2006_b2.lean
+++ b/lean4/src/putnam_2006_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Prove that, for every set $X = \{x_1, x_2, \dots, x_n\}$ of $n$ real numbers, there exists a non-empty subset $S$ of $X$ and an integer $m$ such that

--- a/lean4/src/putnam_2006_b3.lean
+++ b/lean4/src/putnam_2006_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2006_b3_solution : ℕ → ℕ := sorry
 -- (fun n : ℕ => (Nat.choose n 2) + 1)

--- a/lean4/src/putnam_2006_b4.lean
+++ b/lean4/src/putnam_2006_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2006_b4_solution : ℕ → ℕ := sorry
 -- fun k ↦ 2 ^ k

--- a/lean4/src/putnam_2006_b5.lean
+++ b/lean4/src/putnam_2006_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 

--- a/lean4/src/putnam_2006_b6.lean
+++ b/lean4/src/putnam_2006_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Topology Filter
 

--- a/lean4/src/putnam_2007_a1.lean
+++ b/lean4/src/putnam_2007_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2007_a1_solution : Set ℝ := sorry
 -- {2 / 3, 3 / 2, (13 + √601) / 12, (13 - √601) / 12}

--- a/lean4/src/putnam_2007_a2.lean
+++ b/lean4/src/putnam_2007_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2007_a2_solution : ENNReal := sorry
 -- 4

--- a/lean4/src/putnam_2007_a3.lean
+++ b/lean4/src/putnam_2007_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set
 open scoped Nat

--- a/lean4/src/putnam_2007_a4.lean
+++ b/lean4/src/putnam_2007_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat
 

--- a/lean4/src/putnam_2007_a5.lean
+++ b/lean4/src/putnam_2007_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat
 

--- a/lean4/src/putnam_2007_b1.lean
+++ b/lean4/src/putnam_2007_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat
 

--- a/lean4/src/putnam_2007_b2.lean
+++ b/lean4/src/putnam_2007_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Function
 

--- a/lean4/src/putnam_2007_b3.lean
+++ b/lean4/src/putnam_2007_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Function
 

--- a/lean4/src/putnam_2007_b4.lean
+++ b/lean4/src/putnam_2007_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Function
 

--- a/lean4/src/putnam_2007_b5.lean
+++ b/lean4/src/putnam_2007_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Function
 

--- a/lean4/src/putnam_2007_b6.lean
+++ b/lean4/src/putnam_2007_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Set Nat Function
 

--- a/lean4/src/putnam_2008_a1.lean
+++ b/lean4/src/putnam_2008_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $f:\mathbb{R}^2 \to \mathbb{R}$ be a function such that $f(x,y)+f(y,z)+f(z,x)=0$ for all real numbers $x$, $y$, and $z$. Prove that there exists a function $g:\mathbb{R} \to \mathbb{R}$ such that $f(x,y)=g(x)-g(y)$ for all real numbers $x$ and $y$.

--- a/lean4/src/putnam_2008_a3.lean
+++ b/lean4/src/putnam_2008_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Start with a finite sequence $a_1, a_2, \dots, a_n$ of positive integers. If possible, choose two indices $j < k$ such that $a_j$ does not divide $a_k$, and replace $a_j$ and $a_k$ by $\mathrm{gcd}(a_j, a_k)$ and $\mathrm{lcm}(a_j, a_k)$, respectively. Prove that if this process is repeated, it must eventually stop and the final sequence does not depend on the choices made.

--- a/lean4/src/putnam_2008_a4.lean
+++ b/lean4/src/putnam_2008_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2008_a5.lean
+++ b/lean4/src/putnam_2008_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2008_a6.lean
+++ b/lean4/src/putnam_2008_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2008_b1.lean
+++ b/lean4/src/putnam_2008_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2008_b2.lean
+++ b/lean4/src/putnam_2008_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set Nat
 

--- a/lean4/src/putnam_2008_b3.lean
+++ b/lean4/src/putnam_2008_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open FiniteDimensional Metric Filter Topology Set Nat
 

--- a/lean4/src/putnam_2008_b4.lean
+++ b/lean4/src/putnam_2008_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set Nat
 

--- a/lean4/src/putnam_2008_b5.lean
+++ b/lean4/src/putnam_2008_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set Nat
 

--- a/lean4/src/putnam_2008_b6.lean
+++ b/lean4/src/putnam_2008_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set Nat
 

--- a/lean4/src/putnam_2009_a1.lean
+++ b/lean4/src/putnam_2009_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter
 

--- a/lean4/src/putnam_2009_a2.lean
+++ b/lean4/src/putnam_2009_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_a3.lean
+++ b/lean4/src/putnam_2009_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_a4.lean
+++ b/lean4/src/putnam_2009_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_a5.lean
+++ b/lean4/src/putnam_2009_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_b1.lean
+++ b/lean4/src/putnam_2009_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_b2.lean
+++ b/lean4/src/putnam_2009_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_b3.lean
+++ b/lean4/src/putnam_2009_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set
 

--- a/lean4/src/putnam_2009_b4.lean
+++ b/lean4/src/putnam_2009_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set Metric
 

--- a/lean4/src/putnam_2009_b5.lean
+++ b/lean4/src/putnam_2009_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set Metric
 

--- a/lean4/src/putnam_2009_b6.lean
+++ b/lean4/src/putnam_2009_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology MvPolynomial Filter Set Metric
 

--- a/lean4/src/putnam_2010_a1.lean
+++ b/lean4/src/putnam_2010_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2010_a1_solution : ℕ → ℕ := sorry
 -- (fun n : ℕ => Nat.ceil ((n : ℝ) / 2))

--- a/lean4/src/putnam_2010_a2.lean
+++ b/lean4/src/putnam_2010_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2010_a2_solution : Set (ℝ → ℝ) := sorry
 -- {f : ℝ → ℝ | ∃ c d : ℝ, ∀ x : ℝ, f x = c*x + d}

--- a/lean4/src/putnam_2010_a4.lean
+++ b/lean4/src/putnam_2010_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Prove that for each positive integer $n$, the number $10^{10^{10^n}} + 10^{10^n} + 10^n - 1$ is not prime.

--- a/lean4/src/putnam_2010_a5.lean
+++ b/lean4/src/putnam_2010_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $G$ be a group, with operation $*$. Suppose that \begin{enumerate} \item[(i)] $G$ is a subset of $\mathbb{R}^3$ (but $*$ need not be related to addition of vectors); \item[(ii)] For each $\mathbf{a},\mathbf{b} \in G$, either $\mathbf{a}\times \mathbf{b} = \mathbf{a}*\mathbf{b}$ or $\mathbf{a}\times \mathbf{b} = 0$ (or both), where $\times$ is the usual cross product in $\mathbb{R}^3$. \end{enumerate} Prove that $\mathbf{a} \times \mathbf{b} = 0$ for all $\mathbf{a}, \mathbf{b} \in G$.

--- a/lean4/src/putnam_2010_a6.lean
+++ b/lean4/src/putnam_2010_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2010_b1.lean
+++ b/lean4/src/putnam_2010_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2010_b2.lean
+++ b/lean4/src/putnam_2010_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 abbrev putnam_2010_b2_solution : ℕ := sorry

--- a/lean4/src/putnam_2010_b3.lean
+++ b/lean4/src/putnam_2010_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2010_b4.lean
+++ b/lean4/src/putnam_2010_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2010_b5.lean
+++ b/lean4/src/putnam_2010_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2010_b6.lean
+++ b/lean4/src/putnam_2010_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2011_a1.lean
+++ b/lean4/src/putnam_2011_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2011_a1_solution : ℕ := sorry
 -- 10053

--- a/lean4/src/putnam_2011_a2.lean
+++ b/lean4/src/putnam_2011_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2011_a3.lean
+++ b/lean4/src/putnam_2011_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2011_a4.lean
+++ b/lean4/src/putnam_2011_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_a5.lean
+++ b/lean4/src/putnam_2011_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_a6.lean
+++ b/lean4/src/putnam_2011_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_b1.lean
+++ b/lean4/src/putnam_2011_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_b2.lean
+++ b/lean4/src/putnam_2011_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_b3.lean
+++ b/lean4/src/putnam_2011_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_b4.lean
+++ b/lean4/src/putnam_2011_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_b5.lean
+++ b/lean4/src/putnam_2011_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix
 

--- a/lean4/src/putnam_2011_b6.lean
+++ b/lean4/src/putnam_2011_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Matrix Set
 

--- a/lean4/src/putnam_2012_a1.lean
+++ b/lean4/src/putnam_2012_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix
 

--- a/lean4/src/putnam_2012_a2.lean
+++ b/lean4/src/putnam_2012_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix
 

--- a/lean4/src/putnam_2012_a3.lean
+++ b/lean4/src/putnam_2012_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function
 

--- a/lean4/src/putnam_2012_a4.lean
+++ b/lean4/src/putnam_2012_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function
 

--- a/lean4/src/putnam_2012_a5.lean
+++ b/lean4/src/putnam_2012_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function
 

--- a/lean4/src/putnam_2012_a6.lean
+++ b/lean4/src/putnam_2012_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function
 

--- a/lean4/src/putnam_2012_b1.lean
+++ b/lean4/src/putnam_2012_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function Real
 

--- a/lean4/src/putnam_2012_b3.lean
+++ b/lean4/src/putnam_2012_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function Real
 

--- a/lean4/src/putnam_2012_b4.lean
+++ b/lean4/src/putnam_2012_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function Real Topology Filter
 

--- a/lean4/src/putnam_2012_b5.lean
+++ b/lean4/src/putnam_2012_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function Real Topology Filter
 

--- a/lean4/src/putnam_2012_b6.lean
+++ b/lean4/src/putnam_2012_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Matrix Function Real Topology Filter
 

--- a/lean4/src/putnam_2013_a2.lean
+++ b/lean4/src/putnam_2013_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_a3.lean
+++ b/lean4/src/putnam_2013_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_a4.lean
+++ b/lean4/src/putnam_2013_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_a5.lean
+++ b/lean4/src/putnam_2013_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set MeasureTheory
 

--- a/lean4/src/putnam_2013_a6.lean
+++ b/lean4/src/putnam_2013_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_b1.lean
+++ b/lean4/src/putnam_2013_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_b2.lean
+++ b/lean4/src/putnam_2013_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_b3.lean
+++ b/lean4/src/putnam_2013_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_b4.lean
+++ b/lean4/src/putnam_2013_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2013_b5.lean
+++ b/lean4/src/putnam_2013_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function Set
 

--- a/lean4/src/putnam_2014_a1.lean
+++ b/lean4/src/putnam_2014_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2014_a2.lean
+++ b/lean4/src/putnam_2014_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_a3.lean
+++ b/lean4/src/putnam_2014_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_a4.lean
+++ b/lean4/src/putnam_2014_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_a5.lean
+++ b/lean4/src/putnam_2014_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_a6.lean
+++ b/lean4/src/putnam_2014_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_b1.lean
+++ b/lean4/src/putnam_2014_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_b2.lean
+++ b/lean4/src/putnam_2014_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_b3.lean
+++ b/lean4/src/putnam_2014_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_b4.lean
+++ b/lean4/src/putnam_2014_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat
 

--- a/lean4/src/putnam_2014_b6.lean
+++ b/lean4/src/putnam_2014_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Nat Set Interval
 

--- a/lean4/src/putnam_2015_a1.lean
+++ b/lean4/src/putnam_2015_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $A$ and $B$ be points on the same branch of the hyperbola $xy=1$. Suppose that $P$ is a point lying between $A$ and $B$ on this hyperbola, such that the area of the triangle $APB$ is as large as possible. Show that the region bounded by the hyperbola and the chord $AP$ has the same area as the region bounded by the hyperbola and the chord $PB$.

--- a/lean4/src/putnam_2015_a2.lean
+++ b/lean4/src/putnam_2015_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: this problem admits several possible correct solutions; this is the one shown on the solutions document
 abbrev putnam_2015_a2_solution : ℕ := sorry

--- a/lean4/src/putnam_2015_a3.lean
+++ b/lean4/src/putnam_2015_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2015_a3_solution : ℂ := sorry
 -- 13725

--- a/lean4/src/putnam_2015_a4.lean
+++ b/lean4/src/putnam_2015_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2015_a4_solution : ℝ := sorry
 -- 4 / 7

--- a/lean4/src/putnam_2015_a5.lean
+++ b/lean4/src/putnam_2015_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $q$ be an odd positive integer, and let $N_q$ denote the number of integers $a$ such that $0<a<q/4$ and $\gcd(a,q)=1$. Show that $N_q$ is odd if and only if $q$ is of the form $p^k$ with $k$ a positive integer and $p$ a prime congruent to $5$ or $7$ modulo $8$.

--- a/lean4/src/putnam_2015_a6.lean
+++ b/lean4/src/putnam_2015_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $n$ be a positive integer. Suppose that $A$, $B$, and $M$ are $n \times n$ matrices with real entries such that $AM = MB$, and such that $A$ and $B$ have the same characteristic polynomial. Prove that $\det(A-MX)=\det(B-XM)$ for every $n \times n$ matrix $X$ with real entries.

--- a/lean4/src/putnam_2015_b1.lean
+++ b/lean4/src/putnam_2015_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $f$ be a three times differentiable function (defined on $\mathbb{R}$ and real-valued) such that $f$ has at least five distinct real zeros. Prove that $f+6f'+12f''+8f'''$ has at least two distinct real zeros.

--- a/lean4/src/putnam_2015_b2.lean
+++ b/lean4/src/putnam_2015_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2015_b2_solution : Prop := sorry
 -- True

--- a/lean4/src/putnam_2015_b3.lean
+++ b/lean4/src/putnam_2015_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2015_b3_solution : Set (Matrix (Fin 2) (Fin 2) ℝ) := sorry
 -- {A : Matrix (Fin 2) (Fin 2) ℝ | (∃ α : ℝ, ∀ i j : Fin 2, A i j = α * 1) ∨ (∃ β : ℝ, A 0 0 = β * -3 ∧ A 0 1 = β * -1 ∧ A 1 0 = β * 1 ∧ A 1 1 = β * 3)}

--- a/lean4/src/putnam_2015_b4.lean
+++ b/lean4/src/putnam_2015_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2015_b4_solution : ℤ × ℕ := sorry
 -- (17, 21)

--- a/lean4/src/putnam_2015_b5.lean
+++ b/lean4/src/putnam_2015_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_2015_b6.lean
+++ b/lean4/src/putnam_2015_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2016_a1.lean
+++ b/lean4/src/putnam_2016_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat
 

--- a/lean4/src/putnam_2016_a2.lean
+++ b/lean4/src/putnam_2016_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat
 

--- a/lean4/src/putnam_2016_a3.lean
+++ b/lean4/src/putnam_2016_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat
 

--- a/lean4/src/putnam_2016_a5.lean
+++ b/lean4/src/putnam_2016_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2016_a6.lean
+++ b/lean4/src/putnam_2016_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2016_b1.lean
+++ b/lean4/src/putnam_2016_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2016_b2.lean
+++ b/lean4/src/putnam_2016_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Classical Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2016_b3.lean
+++ b/lean4/src/putnam_2016_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2016_b4.lean
+++ b/lean4/src/putnam_2016_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Real Set Nat
 

--- a/lean4/src/putnam_2016_b5.lean
+++ b/lean4/src/putnam_2016_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2016_b6.lean
+++ b/lean4/src/putnam_2016_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial Filter Topology Real Set Nat List
 

--- a/lean4/src/putnam_2017_a1.lean
+++ b/lean4/src/putnam_2017_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2017_a1_solution : Set ℤ := sorry
 -- {x : ℤ | x > 0 ∧ (x = 1 ∨ 5 ∣ x)}

--- a/lean4/src/putnam_2017_a2.lean
+++ b/lean4/src/putnam_2017_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $Q_0(x)=1$, $Q_1(x)=x$, and $Q_n(x)=\frac{(Q_{n-1}(x))^2-1}{Q_{n-2}(x)}$ for all $n \geq 2$. Show that, whenever $n$ is a positive integer, $Q_n(x)$ is equal to a polynomial with integer coefficients.

--- a/lean4/src/putnam_2017_a3.lean
+++ b/lean4/src/putnam_2017_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2017_a4.lean
+++ b/lean4/src/putnam_2017_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2017_b1.lean
+++ b/lean4/src/putnam_2017_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2017_b2.lean
+++ b/lean4/src/putnam_2017_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2017_b3.lean
+++ b/lean4/src/putnam_2017_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2017_b4.lean
+++ b/lean4/src/putnam_2017_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Real
 

--- a/lean4/src/putnam_2017_b6.lean
+++ b/lean4/src/putnam_2017_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Real Function Nat
 

--- a/lean4/src/putnam_2018_a1.lean
+++ b/lean4/src/putnam_2018_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2018_a1_solution : Set (ℤ × ℤ) := sorry
 -- {⟨673, 1358114⟩, ⟨674, 340033⟩, ⟨1009, 2018⟩, ⟨2018, 1009⟩, ⟨340033, 674⟩, ⟨1358114, 673⟩}

--- a/lean4/src/putnam_2018_a2.lean
+++ b/lean4/src/putnam_2018_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2018_a2_solution : ℕ → ℝ := sorry
 -- (fun n : ℕ => if n = 1 then 1 else -1)

--- a/lean4/src/putnam_2018_a3.lean
+++ b/lean4/src/putnam_2018_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 noncomputable abbrev putnam_2018_a3_solution : ℝ := sorry
 -- 480/49

--- a/lean4/src/putnam_2018_a4.lean
+++ b/lean4/src/putnam_2018_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 -- Note: uses (ℕ → ℕ) instead of (Set.Icc 1 n → ℕ)
 /--

--- a/lean4/src/putnam_2018_a5.lean
+++ b/lean4/src/putnam_2018_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $f: \mathbb{R} \to \mathbb{R}$ be an infinitely differentiable function satisfying $f(0) = 0$, $f(1)= 1$, and $f(x) \geq 0$ for all $x \in \mathbb{R}$. Show that there exist a positive integer $n$ and a real number $x$ such that $f^{(n)}(x) < 0$.

--- a/lean4/src/putnam_2018_a6.lean
+++ b/lean4/src/putnam_2018_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Suppose that $A$, $B$, $C$, and $D$ are distinct points, no three of which lie on a line, in the Euclidean plane. Show that if the squares of the lengths of the line segments $AB$, $AC$, $AD$, $BC$, $BD$, and $CD$ are rational numbers, then the quotient $\frac{\text{area}(\triangle ABC)}{\text{area}(\triangle ABD)}$ is a rational number.

--- a/lean4/src/putnam_2018_b1.lean
+++ b/lean4/src/putnam_2018_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2018_b1_solution : Set (Mathlib.Vector ℤ 2) := sorry
 -- {v : Mathlib.Vector ℤ 2 | ∃ b : ℤ, 0 ≤ b ∧ b ≤ 100 ∧ Even b ∧ v.toList = [1, b]}

--- a/lean4/src/putnam_2018_b2.lean
+++ b/lean4/src/putnam_2018_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $n$ be a positive integer, and let $f_n(z) = n + (n-1)z + (n-2)z^2 + \cdots + z^{n-1}$. Prove that $f_n$ has no roots in the closed unit disk $\{z \in \mathbb{C}: |z| \leq 1\}$.

--- a/lean4/src/putnam_2018_b3.lean
+++ b/lean4/src/putnam_2018_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2018_b3_solution : Set ℕ := sorry
 -- {2^2, 2^4, 2^16, 2^256}

--- a/lean4/src/putnam_2018_b4.lean
+++ b/lean4/src/putnam_2018_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Given a real number $a$, we define a sequence by $x_0 = 1$, $x_1 = x_2 = a$, and $x_{n+1} = 2x_n x_{n-1} - x_{n-2}$ for $n \geq 2$. Prove that if $x_n = 0$ for some $n$, then the sequence is periodic.

--- a/lean4/src/putnam_2018_b5.lean
+++ b/lean4/src/putnam_2018_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Function
 

--- a/lean4/src/putnam_2018_b6.lean
+++ b/lean4/src/putnam_2018_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 /--
 Let $S$ be the set of sequences of length $2018$ whose terms are in the set $\{1,2,3,4,5,6,10\}$ and sum to $3860$. Prove that the cardinality of $S$ is at most $2^{3860} \cdot \left(\frac{2018}{2048}\right)^{2018}$.

--- a/lean4/src/putnam_2019_a1.lean
+++ b/lean4/src/putnam_2019_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2019_a3.lean
+++ b/lean4/src/putnam_2019_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2019_a4.lean
+++ b/lean4/src/putnam_2019_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open MeasureTheory Metric Topology Filter
 

--- a/lean4/src/putnam_2019_a5.lean
+++ b/lean4/src/putnam_2019_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2019_a6.lean
+++ b/lean4/src/putnam_2019_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2019_b1.lean
+++ b/lean4/src/putnam_2019_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter
 

--- a/lean4/src/putnam_2019_b2.lean
+++ b/lean4/src/putnam_2019_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set
 

--- a/lean4/src/putnam_2019_b3.lean
+++ b/lean4/src/putnam_2019_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Matrix
 

--- a/lean4/src/putnam_2019_b4.lean
+++ b/lean4/src/putnam_2019_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Matrix
 

--- a/lean4/src/putnam_2019_b5.lean
+++ b/lean4/src/putnam_2019_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Matrix
 

--- a/lean4/src/putnam_2019_b6.lean
+++ b/lean4/src/putnam_2019_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Topology Filter Set Matrix
 

--- a/lean4/src/putnam_2020_a1.lean
+++ b/lean4/src/putnam_2020_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2020_a1_solution : ℕ := sorry
 -- 508536

--- a/lean4/src/putnam_2020_a2.lean
+++ b/lean4/src/putnam_2020_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 abbrev putnam_2020_a2_solution : ℕ → ℕ := sorry
 -- fun k ↦ 4 ^ k

--- a/lean4/src/putnam_2020_a3.lean
+++ b/lean4/src/putnam_2020_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2020_a5.lean
+++ b/lean4/src/putnam_2020_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2020_a6.lean
+++ b/lean4/src/putnam_2020_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2020_b1.lean
+++ b/lean4/src/putnam_2020_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2020_b4.lean
+++ b/lean4/src/putnam_2020_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2020_b5.lean
+++ b/lean4/src/putnam_2020_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2020_b6.lean
+++ b/lean4/src/putnam_2020_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Set
 

--- a/lean4/src/putnam_2021_a1.lean
+++ b/lean4/src/putnam_2021_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_a2.lean
+++ b/lean4/src/putnam_2021_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_a3.lean
+++ b/lean4/src/putnam_2021_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_a4.lean
+++ b/lean4/src/putnam_2021_a4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_2021_a5.lean
+++ b/lean4/src/putnam_2021_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_a6.lean
+++ b/lean4/src/putnam_2021_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_b2.lean
+++ b/lean4/src/putnam_2021_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_b3.lean
+++ b/lean4/src/putnam_2021_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology Metric
 

--- a/lean4/src/putnam_2021_b4.lean
+++ b/lean4/src/putnam_2021_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2021_b5.lean
+++ b/lean4/src/putnam_2021_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Filter Topology
 

--- a/lean4/src/putnam_2022_a1.lean
+++ b/lean4/src/putnam_2022_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_a2.lean
+++ b/lean4/src/putnam_2022_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_a3.lean
+++ b/lean4/src/putnam_2022_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_a6.lean
+++ b/lean4/src/putnam_2022_a6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_b1.lean
+++ b/lean4/src/putnam_2022_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_b2.lean
+++ b/lean4/src/putnam_2022_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_b3.lean
+++ b/lean4/src/putnam_2022_b3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_b4.lean
+++ b/lean4/src/putnam_2022_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_b5.lean
+++ b/lean4/src/putnam_2022_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2022_b6.lean
+++ b/lean4/src/putnam_2022_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Polynomial
 

--- a/lean4/src/putnam_2023_a1.lean
+++ b/lean4/src/putnam_2023_a1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2023_a2.lean
+++ b/lean4/src/putnam_2023_a2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2023_a3.lean
+++ b/lean4/src/putnam_2023_a3.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2023_a5.lean
+++ b/lean4/src/putnam_2023_a5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2023_b1.lean
+++ b/lean4/src/putnam_2023_b1.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2023_b2.lean
+++ b/lean4/src/putnam_2023_b2.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat
 

--- a/lean4/src/putnam_2023_b4.lean
+++ b/lean4/src/putnam_2023_b4.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2023_b5.lean
+++ b/lean4/src/putnam_2023_b5.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 

--- a/lean4/src/putnam_2023_b6.lean
+++ b/lean4/src/putnam_2023_b6.lean
@@ -1,5 +1,4 @@
 import Mathlib
-open BigOperators
 
 open Nat Topology Filter
 


### PR DESCRIPTION
This used to be necessary, but the notation is available globally in recent mathlib versions.