### PR TITLE
fix putnam_2022_a6

### DIFF
--- a/lean4/src/putnam_2022_a6.lean
+++ b/lean4/src/putnam_2022_a6.lean
@@ -13,6 +13,6 @@ theorem putnam_2022_a6
     IsGreatest
       {m : ℕ | ∃ x : ℕ → ℝ,
         StrictMono x ∧ -1 < x 1 ∧ x (2 * n) < 1 ∧
-        ∀ k ∈ Icc 1 m, ∑ i in Finset.Icc 1 n, ((x (2 * i - 1) : ℝ) ^ (2 * k - 1) - (x (2 * i)) ^ (2 * k - 1)) = 1}
+        ∀ k ∈ Icc 1 m, ∑ i in Icc 1 n, ((x (2 * i) : ℝ) ^ (2 * k - 1) - (x (2 * i - 1)) ^ (2 * k - 1)) = 1}
     (putnam_2022_a6_solution n) :=
   sorry


### PR DESCRIPTION
Here the way the length of the interval was measured should be switched, so it has always positive length.

Drive-by: remove a superfluous `Finset`