### PR TITLE
Fix 2018 B3

### DIFF
--- a/lean4/src/putnam_2018_b3.lean
+++ b/lean4/src/putnam_2018_b3.lean
@@ -6,6 +6,6 @@ abbrev putnam_2018_b3_solution : Set ℕ := sorry
 Find all positive integers $n < 10^{100}$ for which simultaneously $n$ divides $2^n$, $n-1$ divides $2^n-1$, and $n-2$ divides $2^n - 2$.
 -/
 theorem putnam_2018_b3
-  (n : ℕ) (hn : n < 0) :
+  (n : ℕ) (hn : 0 < n) :
   (n < 10^100 ∧ ((n : ℤ) ∣ (2^n : ℤ) ∧ (n - 1 : ℤ) ∣ (2^n - 1 : ℤ) ∧ (n - 2 : ℤ) ∣ (2^n - 2 : ℤ))) ↔ n ∈ putnam_2018_b3_solution :=
 sorry


### PR DESCRIPTION
The mistake `n < 0` should be `0 < n`. This was identified in the course of verifying proofs submitted for addition to the leaderboard. 