### PR TITLE
Set won reflexive to Boolean false

### DIFF
--- a/lean4/src/putnam_1965_b2.lean
+++ b/lean4/src/putnam_1965_b2.lean
@@ -9,7 +9,7 @@ theorem putnam_1965_b2
 (n : ℕ)
 (hn : n > 1)
 (won : Fin n → Fin n → Bool)
-(hirrefl : ∀ i : Fin n, won i i = False)
+(hirrefl : ∀ i : Fin n, won i i = false)
 (hantisymm : ∀ i j : Fin n, i ≠ j → won i j = ¬won j i)
 (w l : Fin n → ℤ)
 (hw : w = fun r : Fin n => ∑ j : Fin n, (if won r j then 1 else 0))


### PR DESCRIPTION
Currently, won is defined with co-domain Bool. The reflexive hypothesis assures `won i i = False` using the Prop `False`. Instead, we should use Bool here.