### PR TITLE
Update leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <a href="https://arxiv.org/abs/2407.11214"><img src="https://img.shields.io/badge/arXiv-2407.11214-b31b1b.svg"></a>
 </p>
 
-PutnamBench is a benchmark for evaluation of theorem-proving algorithms on competition mathematics problems sourced from the William Lowell Putnam Mathematical Competition years 1962 - 2023. Our formalizations currently support three formal languages : Lean 4 $\land$ Isabelle $\land$ Coq. PutnamBench comprises of 1696 manually-crafted formalizations, aggregated over all languages.
+PutnamBench is a benchmark for evaluation of theorem-proving algorithms on competition mathematics problems sourced from the William Lowell Putnam Mathematical Competition years 1962 - 2023. Our formalizations currently support three formal languages : Lean 4 $\land$ Isabelle $\land$ Coq. PutnamBench comprises of 1709 manually-crafted formalizations, aggregated over all languages.
 
 PutnamBench aims to support research in automated mathematical reasoning by providing a multilingual benchmark for evaluating theorem-proving algorithms. It is released under permissive licenses (Apache 2.0 for Lean 4 and Isabelle, MIT for Coq). The [informal statements](informal/README.md) are also available with permission from the MAA.
 
@@ -19,7 +19,7 @@ We are hosting a [**leaderboard**](https://trishullab.github.io/PutnamBench/lead
 ## Statistics 
 | Language      | Count          |
 | ------------- | -------------- |
-| Lean 4        | 644            |
+| Lean 4        | 657            |
 | Isabelle      | 640            |
 | Coq           | 412            |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -176,8 +176,8 @@
             We present PutnamBench, a new multilingual benchmark for evaluating the ability of neural theorem-provers to solve competition mathematics problems.    
            </p> 
           <p>
-            PutnamBench consists of 1696 hand-constructed formalizations of problems sourced from the William Lowell Putnam Mathematical Competition, the premier undergraduate-level mathematics competition in North America. 
-            There are 644 problems formalized in Lean 4, 640 formalized in Isabelle, and 412 formalized in Coq.
+            PutnamBench consists of 1709 hand-constructed formalizations of problems sourced from the William Lowell Putnam Mathematical Competition, the premier undergraduate-level mathematics competition in North America. 
+            There are 657 problems formalized in Lean 4, 640 formalized in Isabelle, and 412 formalized in Coq.
           </p>
           <p>
             Proving the theorems requires significant problem-solving ability and proficiency in a broad range of topics taught in undergraduate mathematics courses. We use PutnamBench to evaluate several established neural and symbolic theorem-provers. 

--- a/docs/leaderboard.html
+++ b/docs/leaderboard.html
@@ -134,7 +134,7 @@
       <!-- <div id="chart" style="width: 100%; height: 600px"></div> -->
       <div class="container-fluid d-flex flex-row flex-nowrap">
         <div class="container-fluid d-flex flex-column align-items-center">
-          <label for="lean" style="font-size: 14px;" class="text-success mb-3">Lean (out of 644)</label>
+          <label for="lean" style="font-size: 14px;" class="text-success mb-3">Lean (out of 657)</label>
           <table
             id="lean"
             class="table table-responsive table-striped table-bordered flex-shrink-1 border border-success border-3"
@@ -161,6 +161,9 @@
           <ol>
             <li>
               As no existing methods have been benchmarked on PutnamBench <em>without numerical answers in the theorem statement</em>, the leaderboard for that variant contains no entries. Please share you results with us and we will promptly update the leaderboard!
+            </li>
+            <li>
+              Some new problems have been added since original release, benchmarked methods have not been rerun on those problems, but PutnamBench version used in the eval is mentioned in the repo's `results.json`.
             </li>
             <li>
               We are open to suggestions for better indicating the differing compute budgets of approaches on the leaderboard. Please reach out to us with your ideas!

--- a/docs/results.json
+++ b/docs/results.json
@@ -52,6 +52,16 @@
       "condensed-compute-budget": "pass@1",
       "note": "pass@1 w/ t=120s; 1971 B1, 2001 A1, 2012 A2."
     },
+    "Deepseek R1": {
+      "link": "https://huggingface.co/deepseek-ai/DeepSeek-R1",
+      "open-data": "FULL",
+      "num-solved": {
+        "lean-wsolution": 0
+      },
+      "size": 0,
+      "condensed-compute-budget": "pass@1",
+      "note: pass@1 evaluated using FTPEvals, commit 0da3032, cost: ~$5"
+    },
     "ReProver w/ retrieval": {
       "link": "https://arxiv.org/abs/2306.15626",
       "open-data": "FULL",
@@ -131,5 +141,45 @@
       "size": 7.0,
       "condensed-compute-budget": "pass@3200",
       "note": "pass@3200 w/ T = 0.7, w/ miniF2F-valid, ProofNet-valid; 1986 B1, 1988 B2, 2008 A1, 1988 B1, 1977 A3, 2001 A1, 1986 A1, 1990 A1. Commit: b377431; pass@64 yields 7/644"
+    },
+    "o3-mini" : {
+      "link": "https://openai.com/index/openai-o3-mini/",
+      "open-data": "NONE",
+      "num-solved": {
+        "lean-wsolution": 0
+      },
+      "size": 0,
+      "condensed-compute-budget": "pass@1",
+      "note" : "pass@1 using FTPEvals, commit 0da3032, cost: $20"
+    },
+    "claude-3.7-sonnet" : {
+      "link": "https://www.anthropic.com/claude/sonnet",
+      "open-data": "NONE",
+      "num-solved": {
+        "lean-wsolution": 0
+      },
+      "size": 0,
+      "condensed-compute-budget": "pass@1",
+      "note" : "pass@1 using FTPEvals, commit 0da3032, cost: $21"
+    },
+    "gemini-2.0-flash-thinking-121" : {
+      "link": "https://deepmind.google/technologies/gemini/flash-thinking/",
+      "open-data": "NONE",
+      "num-solved": {
+        "lean-wsolution": 0
+      },
+      "size": 0,
+      "condensed-compute-budget": "pass@1",
+      "note" : "pass@1 using FTPEvals, commit 0da3032, cost: free"
+    },
+    "GPT-4o-mini": {
+      "link": "https://openai.com/index/hello-gpt-4o/",
+      "open-data": "NONE",
+      "num-solved": {
+        "lean-wsolution": 0
+      },
+      "size": 0,
+      "condensed-compute-budget": "pass@1",
+      "note": "pass@1 w/ T=0.7; evaluated using FTPEvals"
     }
 }

--- a/lean4/src/putnam_2024_a4.lean
+++ b/lean4/src/putnam_2024_a4.lean
@@ -11,5 +11,5 @@ theorem putnam_2024_a4 :
       ∃ e : ℕ → ℕ, Set.BijOn e (Set.Icc 0 (p - 5 : ℕ)) (Set.Icc 0 (p - 5 : ℕ)) ∧
         ∀ n, 1 ≤ n ∧ n ≤ (p - 5 : ℕ) →
           (p : ℤ) ∣ a ^ (e n : ℕ) - a ^ (e (n - 1) : ℕ) - r} =
-    putnam_2024_a4_solution := by
+    putnam_2024_a4_solution :=
   sorry

--- a/lean4/src/putnam_2024_a5.lean
+++ b/lean4/src/putnam_2024_a5.lean
@@ -22,5 +22,5 @@ theorem putnam_2024_a5
           ((WithLp.equiv _ _).symm ![9 * Real.cos (2 * Real.pi * s), 9 * Real.sin (2 * Real.pi * s)])
           ((WithLp.equiv _ _).symm ![9 * Real.cos (2 * Real.pi * t), 9 * Real.sin (2 * Real.pi * t)]) }) :
     {r | r ∈ Set.Icc 0 8 ∧ ProbIntersect r = ⨅ x ∈ Set.Icc 0 8, ProbIntersect x} =
-      putnam_2024_a5_solution := by
+      putnam_2024_a5_solution :=
   sorry

--- a/lean4/src/putnam_2024_b3.lean
+++ b/lean4/src/putnam_2024_b3.lean
@@ -16,5 +16,5 @@ theorem putnam_2024_b3
         Real.tan (r n) = r n ∧
         ∀ x, x ∈ Set.Ioo (r n) (r (n + 1)) → Real.tan x ≠ x)
     (n : ℕ+) :
-    r (n + 1) - r n - Real.pi ∈ Set.Ioo (0 : ℝ) (1 / ((n ^ 2 + n) * Real.pi)) := by
+    r (n + 1) - r n - Real.pi ∈ Set.Ioo (0 : ℝ) (1 / ((n ^ 2 + n) * Real.pi)) :=
   sorry

--- a/lean4/src/putnam_2024_b5.lean
+++ b/lean4/src/putnam_2024_b5.lean
@@ -17,5 +17,5 @@ theorem putnam_2024_b5
         IsQualifyingSeq x z ∧ IsQualifyingSeq y z ∧ z ≤ n}.ncard) :
     ∃ P : ℚ[X],
       (∀ n > 0, f n = P.eval (n : ℚ)) ∧
-      (∀ i, 0 ≤ P.coeff i) := by
+      (∀ i, 0 ≤ P.coeff i) :=
   sorry

--- a/lean4/src/putnam_2024_b6.lean
+++ b/lean4/src/putnam_2024_b6.lean
@@ -15,5 +15,5 @@ theorem putnam_2024_b6
       HasSum (fun (n : ℕ) => (n+1)^a * rexp (2*(n+1)) * x^(n+1)^2) (F a x)) :
     ((∀ a < c, Filter.Tendsto (fun x => F a x * rexp (- 1 / (1-x))) (𝓝[<] 1) (𝓝 0)) ∧
     (∀ a > c, Filter.Tendsto (fun x => F a x * rexp (- 1 / (1-x))) (𝓝[<] 1) Filter.atTop))
-    ↔ c = putnam_2024_b6_solution := by
+    ↔ c = putnam_2024_b6_solution :=
   sorry


### PR DESCRIPTION
Added evaluations of 4 LRMs from OpenAI, Google, Anthropic, and Deepseek on PutnamBench, as well as some numeric changes reflecting the new number of problems and some consistency changes for Putnam 2024 problems.