### PR TITLE
lean: fix deprecation warnings

### DIFF
--- a/lean4/src/putnam_1962_a5.lean
+++ b/lean4/src/putnam_1962_a5.lean
@@ -6,5 +6,5 @@ abbrev putnam_1962_a5_solution : ℕ → ℕ := sorry
 Evaluate in closed form \[ \sum_{k=1}^n {n \choose k} k^2. \]
 -/
 theorem putnam_1962_a5
-: ∀ n ≥ 2, putnam_1962_a5_solution n = ∑ k in Finset.Icc 1 n, Nat.choose n k * k^2 :=
+: ∀ n ≥ 2, putnam_1962_a5_solution n = ∑ k ∈ Finset.Icc 1 n, Nat.choose n k * k^2 :=
 sorry

--- a/lean4/src/putnam_1962_b1.lean
+++ b/lean4/src/putnam_1962_b1.lean
@@ -8,6 +8,6 @@ theorem putnam_1962_b1
 (x y : ℝ)
 (n : ℕ)
 (h0 : p 0 = fun x : ℝ => 1)
-(hp : ∀ n > 0, p n = fun x : ℝ => ∏ i in Finset.range n, (x - i))
-: p n (x+y) = ∑ k in Finset.range (n+1), Nat.choose n k * (p k x) * (p (n - k) y) :=
+(hp : ∀ n > 0, p n = fun x : ℝ => ∏ i ∈ Finset.range n, (x - i))
+: p n (x+y) = ∑ k ∈ Finset.range (n+1), Nat.choose n k * (p k x) * (p (n - k) y) :=
 sorry

--- a/lean4/src/putnam_1962_b6.lean
+++ b/lean4/src/putnam_1962_b6.lean
@@ -10,7 +10,7 @@ theorem putnam_1962_b6
 (a b : ℕ → ℝ)
 (xs : Set ℝ)
 (f : ℝ → ℝ)
-(hf : f = fun x : ℝ => ∑ k in Finset.Icc 0 n, ((a k) * Real.sin (k * x) + (b k) * Real.cos (k * x)))
+(hf : f = fun x : ℝ => ∑ k ∈ Finset.Icc 0 n, ((a k) * Real.sin (k * x) + (b k) * Real.cos (k * x)))
 (hf1 : ∀ x ∈ Set.Icc 0 (2 * π), |f x| ≤ 1)
 (hxs : xs.ncard = 2 * n ∧ xs ⊆ Set.Ico 0 (2 * π))
 (hfxs : ∀ x ∈ xs, |f x| = 1)

--- a/lean4/src/putnam_1964_a5.lean
+++ b/lean4/src/putnam_1964_a5.lean
@@ -10,7 +10,7 @@ Prove that there exists a constant $k$ such that for any sequence $a_i$ of posit
 -/
 theorem putnam_1964_a5
     (pa : (ℕ → ℝ) → Prop)
-    (hpa : ∀ a, pa a ↔ (∀ n : ℕ, a n > 0) ∧ ∃ L : ℝ, Tendsto (fun N ↦ ∑ n in Finset.range N, 1 / a n) atTop (𝓝 L)) :
+    (hpa : ∀ a, pa a ↔ (∀ n : ℕ, a n > 0) ∧ ∃ L : ℝ, Tendsto (fun N ↦ ∑ n ∈ Finset.range N, 1 / a n) atTop (𝓝 L)) :
     ∃ k : ℝ, ∀ a : ℕ → ℝ, pa a →
-      ∑' n : ℕ, (n + 1) / (∑ i in Finset.range (n + 1), a i) ≤ k * ∑' n : ℕ, 1 / a n :=
+      ∑' n : ℕ, (n + 1) / (∑ i ∈ Finset.range (n + 1), a i) ≤ k * ∑' n : ℕ, 1 / a n :=
   sorry

--- a/lean4/src/putnam_1964_b5.lean
+++ b/lean4/src/putnam_1964_b5.lean
@@ -9,5 +9,5 @@ theorem putnam_1964_b5
 (a b : ℕ → ℕ)
 (ha : StrictMono a ∧ ∀ n : ℕ, a n > 0)
 (hb : b 0 = a 0 ∧ ∀ n : ℕ, b (n + 1) = lcm (b n) (a (n + 1)))
-: (∃ L : ℝ, Tendsto (fun N ↦ ∑ n in Finset.range N, (1 : ℝ) / b n) atTop (𝓝 L)) :=
+: (∃ L : ℝ, Tendsto (fun N ↦ ∑ n ∈ Finset.range N, (1 : ℝ) / b n) atTop (𝓝 L)) :=
 sorry

--- a/lean4/src/putnam_1965_a2.lean
+++ b/lean4/src/putnam_1965_a2.lean
@@ -6,5 +6,5 @@ open EuclideanGeometry
 Prove that $$\sum_{r=0}^{\lfloor\frac{n-1}{2}\rfloor} \left(\frac{n - 2r}{n} {n \choose r}\right)^2 = \frac{1}{n} {{2n - 2} \choose {n - 1}}$$ for every positive integer $n$.
 -/
 theorem putnam_1965_a2
-: ∀ n > 0, ∑ r in Finset.Icc 0 ((n - 1)/2), ((n - 2*r) * Nat.choose n r / (n : ℚ))^2 = (Nat.choose (2*n - 2) (n - 1))/(n : ℚ) :=
+: ∀ n > 0, ∑ r ∈ Finset.Icc 0 ((n - 1)/2), ((n - 2*r) * Nat.choose n r / (n : ℚ))^2 = (Nat.choose (2*n - 2) (n - 1))/(n : ℚ) :=
 sorry

--- a/lean4/src/putnam_1965_a3.lean
+++ b/lean4/src/putnam_1965_a3.lean
@@ -8,6 +8,6 @@ Prove that, for any sequence of real numbers $a_1, a_2, \dots$, $$\lim_{n \to \i
 theorem putnam_1965_a3
 (a : ℕ → ℝ)
 (α : ℂ)
-: Tendsto (fun n : ℕ => (∑ k in Finset.Icc 1 n, exp (I * a k))/n) atTop (𝓝 α) ↔
-Tendsto (fun n : ℕ => (∑ k in Finset.Icc 1 (n^2), exp (I * a k))/n^2) atTop (𝓝 α) :=
+: Tendsto (fun n : ℕ => (∑ k ∈ Finset.Icc 1 n, exp (I * a k))/n) atTop (𝓝 α) ↔
+Tendsto (fun n : ℕ => (∑ k ∈ Finset.Icc 1 (n^2), exp (I * a k))/n^2) atTop (𝓝 α) :=
 sorry

--- a/lean4/src/putnam_1965_b4.lean
+++ b/lean4/src/putnam_1965_b4.lean
@@ -9,8 +9,8 @@ Let $$f(x, n) = \frac{{n \choose 0} + {n \choose 2}x + {n \choose 4}x^2 + \cdots
 -/
 theorem putnam_1965_b4
     (f u v : ℕ → ℝ → ℝ)
-    (hu : ∀ n > 0, ∀ x, u n x = ∑ i in Finset.Icc 0 (n / 2), (n.choose (2 * i)) * x ^ i)
-    (hv : ∀ n > 0, ∀ x, v n x = ∑ i in Finset.Icc 0 ((n - 1) / 2), (n.choose (2 * i + 1)) * x ^ i)
+    (hu : ∀ n > 0, ∀ x, u n x = ∑ i ∈ Finset.Icc 0 (n / 2), (n.choose (2 * i)) * x ^ i)
+    (hv : ∀ n > 0, ∀ x, v n x = ∑ i ∈ Finset.Icc 0 ((n - 1) / 2), (n.choose (2 * i + 1)) * x ^ i)
     (hf : ∀ n > 0, ∀ x, f n x = u n x / v n x)
     (n : ℕ)
     (hn : 0 < n) :

--- a/lean4/src/putnam_1966_a1.lean
+++ b/lean4/src/putnam_1966_a1.lean
@@ -5,6 +5,6 @@ Let $a_n$ denote the sequence $0, 1, 1, 2, 2, 3, \dots$, where $a_n = \frac{n}{2
 -/
 theorem putnam_1966_a1
 (f : ℤ → ℤ)
-(hf : f = fun n : ℤ => ∑ m in Finset.Icc 0 n, (if Even m then m / 2 else (m - 1)/2))
+(hf : f = fun n : ℤ => ∑ m ∈ Finset.Icc 0 n, (if Even m then m / 2 else (m - 1)/2))
 : ∀ x y : ℤ, x > 0 ∧ y > 0 ∧ x > y → x * y = f (x + y) - f (x - y) :=
 sorry

--- a/lean4/src/putnam_1966_b3.lean
+++ b/lean4/src/putnam_1966_b3.lean
@@ -8,6 +8,6 @@ Let $p_1, p_2, \dots$ be a sequence of positive real numbers. Prove that if $\su
 theorem putnam_1966_b3
 (p : ℕ → ℝ)
 (hpos : ∀ n : ℕ, p n > 0)
-(hconv : ∃ r : ℝ, Tendsto (fun m : ℕ => ∑ n in Finset.Icc 1 m, 1/(p n)) atTop (𝓝 r))
-: ∃ r : ℝ, Tendsto (fun m : ℕ => ∑ n in Finset.Icc 1 m, (p n) * n^2/(∑ i in Finset.Icc 1 n, p i)^2) atTop (𝓝 r) :=
+(hconv : ∃ r : ℝ, Tendsto (fun m : ℕ => ∑ n ∈ Finset.Icc 1 m, 1/(p n)) atTop (𝓝 r))
+: ∃ r : ℝ, Tendsto (fun m : ℕ => ∑ n ∈ Finset.Icc 1 m, (p n) * n^2/(∑ i ∈ Finset.Icc 1 n, p i)^2) atTop (𝓝 r) :=
 sorry

--- a/lean4/src/putnam_1967_b5.lean
+++ b/lean4/src/putnam_1967_b5.lean
@@ -8,5 +8,5 @@ For any positive integer $n$, prove that the sum of the first $n$ terms of the b
 theorem putnam_1967_b5
 (n : ℕ)
 (hn : n > 0)
-: (1 : ℚ)/2 = ∑ i in Finset.range n, (Nat.choose (n + i - 1) i) * (2 : ℚ)^(-(n : ℤ) - i) :=
+: (1 : ℚ)/2 = ∑ i ∈ Finset.range n, (Nat.choose (n + i - 1) i) * (2 : ℚ)^(-(n : ℤ) - i) :=
 sorry

--- a/lean4/src/putnam_1969_a4.lean
+++ b/lean4/src/putnam_1969_a4.lean
@@ -6,5 +6,5 @@ open Matrix Filter Topology Set Nat
 Show that $\int_0^1 x^x dx = \sum_{n=1}^{\infty} (-1)^{n+1}n^{-n}$.
 -/
 theorem putnam_1969_a4
-: Tendsto (fun n => ∑ i in Finset.Icc (1 : ℤ) n, (-1)^(i+1)*(i : ℝ)^(-i)) atTop (𝓝 (∫ x in Ioo (0 : ℝ) 1, x^x)) :=
+: Tendsto (fun n => ∑ i ∈ Finset.Icc (1 : ℤ) n, (-1)^(i+1)*(i : ℝ)^(-i)) atTop (𝓝 (∫ x in Ioo (0 : ℝ) 1, x^x)) :=
 sorry

--- a/lean4/src/putnam_1969_b1.lean
+++ b/lean4/src/putnam_1969_b1.lean
@@ -9,5 +9,5 @@ theorem putnam_1969_b1
 (n : ℕ)
 (hnpos : n > 0)
 (hn : 24 ∣ n + 1)
-: 24 ∣ ∑ d in divisors n, d :=
+: 24 ∣ ∑ d ∈ divisors n, d :=
 sorry

--- a/lean4/src/putnam_1970_b1.lean
+++ b/lean4/src/putnam_1970_b1.lean
@@ -8,5 +8,5 @@ noncomputable abbrev putnam_1970_b1_solution : ℝ := sorry
 Evaluate the infinite product $\lim_{n \to \infty} \frac{1}{n^4} \prod_{i = 1}^{2n} (n^2 + i^2)^{1/n}$.
 -/
 theorem putnam_1970_b1
-: Tendsto (fun n => 1/(n^4) * ∏ i in Finset.Icc (1 : ℤ) (2*n), ((n^2 + i^2) : ℝ)^((1 : ℝ)/n)) atTop (𝓝 putnam_1970_b1_solution) :=
+: Tendsto (fun n => 1/(n^4) * ∏ i ∈ Finset.Icc (1 : ℤ) (2*n), ((n^2 + i^2) : ℝ)^((1 : ℝ)/n)) atTop (𝓝 putnam_1970_b1_solution) :=
 sorry

--- a/lean4/src/putnam_1971_b6.lean
+++ b/lean4/src/putnam_1971_b6.lean
@@ -8,5 +8,5 @@ Let $\delta(x) be the greatest odd divisor of the positive integer $x$. Show tha
 theorem putnam_1971_b6
 (δ : ℤ → ℤ)
 (hδ : δ = fun n => sSup {t | Odd t ∧ t ∣ n})
-: ∀ x : ℤ, x > 0 → |∑ i in Finset.Icc 1 x, (δ i)/(i : ℚ) - 2*x/3| < 1 :=
+: ∀ x : ℤ, x > 0 → |∑ i ∈ Finset.Icc 1 x, (δ i)/(i : ℚ) - 2*x/3| < 1 :=
 sorry

--- a/lean4/src/putnam_1972_a3.lean
+++ b/lean4/src/putnam_1972_a3.lean
@@ -11,7 +11,7 @@ We call a function $f$ from $[0,1]$ to the reals to be supercontinuous on $[0,1]
 theorem putnam_1972_a3
     (climit_exists : (ℕ → ℝ) → Prop)
     (supercontinuous : (ℝ → ℝ) → Prop)
-    (hclimit_exists : ∀ x, climit_exists x ↔ ∃ C : ℝ, Tendsto (fun n => (∑ i in Finset.range n, (x i))/(n : ℝ)) atTop (𝓝 C))
+    (hclimit_exists : ∀ x, climit_exists x ↔ ∃ C : ℝ, Tendsto (fun n => (∑ i ∈ Finset.range n, (x i))/(n : ℝ)) atTop (𝓝 C))
     (hsupercontinuous : ∀ f, supercontinuous f ↔ ∀ (x : ℕ → ℝ), (∀ i : ℕ, x i ∈ Icc 0 1) → climit_exists x → climit_exists (fun i => f (x i))) :
     {f | supercontinuous f} = putnam_1972_a3_solution :=
   sorry

--- a/lean4/src/putnam_1973_a2.lean
+++ b/lean4/src/putnam_1973_a2.lean
@@ -13,6 +13,6 @@ theorem putnam_1973_a2
 (pluses : ℕ)
 (hpluses : pluses = {i : Fin L.length | L[i] = 1}.ncard)
 (S : ℕ → ℝ)
-(hS : S = fun n : ℕ ↦ ∑ i in Finset.Icc 1 n, L[i % 8]/i)
+(hS : S = fun n : ℕ ↦ ∑ i ∈ Finset.Icc 1 n, L[i % 8]/i)
 : (pluses = 4 → ∃ l : ℝ, Tendsto S atTop (𝓝 l)) ∧ (putnam_1973_a2_solution ↔ ((∃ l : ℝ, Tendsto S atTop (𝓝 l)) → pluses = 4)) :=
 sorry

--- a/lean4/src/putnam_1973_b1.lean
+++ b/lean4/src/putnam_1973_b1.lean
@@ -8,6 +8,6 @@ Let $a_1, \dots, a_{2n + 1}$ be a set of integers such that, if any one of them 
 theorem putnam_1973_b1
 (n : ℕ)
 (a : Finset.Icc 1 (2 * n + 1) → ℤ)
-(h_remove : ∀ S : Finset (Finset.Icc 1 (2 * n + 1)), S.card = 2*n → ∃ T, T ⊆ S ∧ T.card = n ∧ ∑ i in T, a i = ∑ i in (S \ T), a i)
+(h_remove : ∀ S : Finset (Finset.Icc 1 (2 * n + 1)), S.card = 2*n → ∃ T, T ⊆ S ∧ T.card = n ∧ ∑ i ∈ T, a i = ∑ i ∈ (S \ T), a i)
 : ∀ i j : Finset.Icc 1 (2 * n + 1), a i = a j :=
 sorry

--- a/lean4/src/putnam_1974_a4.lean
+++ b/lean4/src/putnam_1974_a4.lean
@@ -11,6 +11,6 @@ Evaluate in closed form: $\frac{1}{2^{n-1}} \sum_{k < n/2} (n-2k)*{n \choose k}$
 theorem putnam_1974_a4
     (n : ℕ)
     (hn : 0 < n) :
-    (1 : ℚ) / (2 ^ (n - 1)) * ∑ k in Finset.Icc 0 ⌊n / 2⌋₊, (n - 2 * k) * (n.choose k) =
+    (1 : ℚ) / (2 ^ (n - 1)) * ∑ k ∈ Finset.Icc 0 ⌊n / 2⌋₊, (n - 2 * k) * (n.choose k) =
     putnam_1974_a4_solution n :=
   sorry

--- a/lean4/src/putnam_1974_b5.lean
+++ b/lean4/src/putnam_1974_b5.lean
@@ -6,5 +6,5 @@ open Set Nat Polynomial Filter Topology
 Show that $1 + (n/1!) + (n^2/2!) + \dots + (n^n/n!) > e^n/2$ for every integer $n \geq 0$.
 -/
 theorem putnam_1974_b5
-: ∀ n ≥ 0, ∑ i in Finset.Icc (0 : ℕ) n, (n^i : ℝ)/(Nat.factorial i) > (Real.exp n)/2 :=
+: ∀ n ≥ 0, ∑ i ∈ Finset.Icc (0 : ℕ) n, (n^i : ℝ)/(Nat.factorial i) > (Real.exp n)/2 :=
 sorry

--- a/lean4/src/putnam_1975_a4.lean
+++ b/lean4/src/putnam_1975_a4.lean
@@ -3,7 +3,7 @@ import Mathlib
 open Polynomial Real Complex
 
 noncomputable abbrev putnam_1975_a4_solution : ℕ → Polynomial ℤ := sorry
--- fun m => ∑ j in Finset.range ((m - 1) / 2), Polynomial.X ^ (2 * j + 1)
+-- fun m => ∑ j ∈ Finset.range ((m - 1) / 2), Polynomial.X ^ (2 * j + 1)
 /--
 Let $n = 2m$, where $m$ is an odd integer greater than 1. Let $\theta = e^{2\pi i/n}$. Expression $(1 - \theta)^{-1}$ explicitly as a polynomial in $\theta$ \[ a_k \theta^k  + a_{k-1}\theta^{k-1} + \dots + a_1\theta + a_0\], with integer coefficients $a_i$.
 -/

--- a/lean4/src/putnam_1975_b2.lean
+++ b/lean4/src/putnam_1975_b2.lean
@@ -13,6 +13,6 @@ theorem putnam_1975_b2
 (thicknesses : ℕ → ℝ)
 (hnormalsunit : ∀ i : ℕ, ‖normals i‖ = 1)
 (hthicknessespos : ∀ i : ℕ, thicknesses i > 0)
-(hthicknessesconv : ∃ C : ℝ, Tendsto (fun i : ℕ => ∑ j in Finset.range i, thicknesses j) atTop (𝓝 C))
+(hthicknessesconv : ∃ C : ℝ, Tendsto (fun i : ℕ => ∑ j ∈ Finset.range i, thicknesses j) atTop (𝓝 C))
 : Set.univ ≠ ⋃ i : ℕ, slab (normals i) (offsets i) (thicknesses i) :=
 sorry

--- a/lean4/src/putnam_1975_b6.lean
+++ b/lean4/src/putnam_1975_b6.lean
@@ -7,6 +7,6 @@ Show that if $s_n = 1 + \frac{1}{2} + \frac{1}{3} + \dots + 1/n, then $n(n+1)^{1
 -/
 theorem putnam_1975_b6
 (s : ℕ → ℝ)
-(hs : s = fun (n : ℕ) => ∑ i in Finset.Icc 1 n, 1/(i : ℝ))
+(hs : s = fun (n : ℕ) => ∑ i ∈ Finset.Icc 1 n, 1/(i : ℝ))
 : (∀ n : ℕ, n > 1 → n * (n+1 : ℝ)^(1/(n : ℝ)) < n + s n) ∧ (∀ n : ℕ, n > 2 → ((n : ℝ) - 1)*((n : ℝ)^(-1/(n-1 : ℝ))) < n - s n) :=
 sorry

--- a/lean4/src/putnam_1976_b1.lean
+++ b/lean4/src/putnam_1976_b1.lean
@@ -8,6 +8,6 @@ abbrev putnam_1976_b1_solution : ℕ × ℕ := sorry
 Find $$\lim_{n \to \infty} \frac{1}{n} \sum_{k=1}^{n}\left(\left\lfloor \frac{2n}{k} \right\rfloor - 2\left\lfloor \frac{n}{k} \right\rfloor\right).$$ Your answer should be in the form $\ln(a) - b$, where $a$ and $b$ are positive integers.
 -/
 theorem putnam_1976_b1
-: Tendsto (fun n : ℕ => ((1 : ℝ)/n)*∑ k in Finset.Icc (1 : ℤ) n, (Int.floor ((2*n)/k) - 2*Int.floor (n/k))) atTop
+: Tendsto (fun n : ℕ => ((1 : ℝ)/n)*∑ k ∈ Finset.Icc (1 : ℤ) n, (Int.floor ((2*n)/k) - 2*Int.floor (n/k))) atTop
 (𝓝 (Real.log putnam_1976_b1_solution.1 - putnam_1976_b1_solution.2)) :=
 sorry

--- a/lean4/src/putnam_1976_b5.lean
+++ b/lean4/src/putnam_1976_b5.lean
@@ -8,5 +8,5 @@ noncomputable abbrev putnam_1976_b5_solution : ℕ → Polynomial ℤ := sorry
 Find $$\sum_{k=0}^{n} (-1)^k {n \choose k} (x - k)^n.$$
 -/
 theorem putnam_1976_b5
-: ∀ n : ℕ, ∑ k in Finset.range (n + 1), C ((-(1 : ℤ))^k * Nat.choose n k) * (X - (C (k : ℤ)))^n = putnam_1976_b5_solution n :=
+: ∀ n : ℕ, ∑ k ∈ Finset.range (n + 1), C ((-(1 : ℤ))^k * Nat.choose n k) * (X - (C (k : ℤ)))^n = putnam_1976_b5_solution n :=
 sorry

--- a/lean4/src/putnam_1976_b6.lean
+++ b/lean4/src/putnam_1976_b6.lean
@@ -7,7 +7,7 @@ Let $\sigma(N)$ denote the sum of all positive integer divisors of $N$, includin
 -/
 theorem putnam_1976_b6
 (σ : ℕ → ℤ)
-(hσ : σ = fun N : ℕ => ∑ d in Nat.divisors N, (d : ℤ))
+(hσ : σ = fun N : ℕ => ∑ d ∈ Nat.divisors N, (d : ℤ))
 (quasiperfect : ℕ → Prop)
 (quasiperfect_def : ∀ N, quasiperfect N ↔ σ N = 2*N + 1)
 : ∀ N : ℕ, quasiperfect N → ∃ m : ℤ, Odd m ∧ m^2 = N :=

--- a/lean4/src/putnam_1977_a1.lean
+++ b/lean4/src/putnam_1977_a1.lean
@@ -10,5 +10,5 @@ theorem putnam_1977_a1
 (hy : y = fun x ↦ 2 * x ^ 4 + 7 * x ^ 3 + 3 * x - 5)
 (S : Finset ℝ)
 (hS : S.card = 4)
-: (Collinear ℝ {P : Fin 2 → ℝ | P 0 ∈ S ∧ P 1 = y (P 0)} → (∑ x in S, x) / 4 = putnam_1977_a1_solution) :=
+: (Collinear ℝ {P : Fin 2 → ℝ | P 0 ∈ S ∧ P 1 = y (P 0)} → (∑ x ∈ S, x) / 4 = putnam_1977_a1_solution) :=
 sorry

--- a/lean4/src/putnam_1977_b1.lean
+++ b/lean4/src/putnam_1977_b1.lean
@@ -8,5 +8,5 @@ noncomputable abbrev putnam_1977_b1_solution : ℝ := sorry
 Find $\prod_{n=2}^{\infty} \frac{(n^3 - 1)}{(n^3 + 1)}$.
 -/
 theorem putnam_1977_b1
-: Tendsto (fun N ↦ ∏ n in Finset.Icc (2 : ℤ) N, ((n : ℝ) ^ 3 - 1) / (n ^ 3 + 1)) atTop (𝓝 putnam_1977_b1_solution) :=
+: Tendsto (fun N ↦ ∏ n ∈ Finset.Icc (2 : ℤ) N, ((n : ℝ) ^ 3 - 1) / (n ^ 3 + 1)) atTop (𝓝 putnam_1977_b1_solution) :=
 sorry

--- a/lean4/src/putnam_1978_b6.lean
+++ b/lean4/src/putnam_1978_b6.lean
@@ -13,5 +13,5 @@ theorem putnam_1978_b6
 (ha : ∀ i j, a i j ∈ Icc 0 1)
 (m n : ℕ)
 (mnpos : m > 0 ∧ n > 0)
-: ((∑ i in Finset.Icc 1 n, ∑ j in Finset.Icc 1 (m * i), a i j / i) ^ 2 ≤ 2 * m * ∑ i in Finset.Icc 1 n, ∑ j in Finset.Icc 1 (m * i), a i j) :=
+: ((∑ i ∈ Finset.Icc 1 n, ∑ j ∈ Finset.Icc 1 (m * i), a i j / i) ^ 2 ≤ 2 * m * ∑ i ∈ Finset.Icc 1 n, ∑ j ∈ Finset.Icc 1 (m * i), a i j) :=
 sorry

--- a/lean4/src/putnam_1979_a6.lean
+++ b/lean4/src/putnam_1979_a6.lean
@@ -9,5 +9,5 @@ theorem putnam_1979_a6
 (n : ℕ)
 (p : ℕ → ℝ)
 (hp : ∀ i ∈ Finset.range n, p i ∈ Icc 0 1)
-: ∃ x ∈ Icc 0 1, (∀ i ∈ Finset.range n, x ≠ p i) ∧ ∑ i in Finset.range n, 1/|x - p i| ≤ 8*n*∑ i in Finset.range n, (1 : ℝ)/(2*i + 1) :=
+: ∃ x ∈ Icc 0 1, (∀ i ∈ Finset.range n, x ≠ p i) ∧ ∑ i ∈ Finset.range n, 1/|x - p i| ≤ 8*n*∑ i ∈ Finset.range n, (1 : ℝ)/(2*i + 1) :=
 sorry

--- a/lean4/src/putnam_1980_b6.lean
+++ b/lean4/src/putnam_1980_b6.lean
@@ -7,6 +7,6 @@ For integers $d, n$ with $1 \le d \le n$, let $G(1, n) = \frac{1}{n}$ and $G(d, 
 -/
 theorem putnam_1980_b6
 (G : ℤ × ℤ → ℚ)
-(hG : ∀ d n : ℕ, d ≤ n → (d = 1 → G (d, n) = 1/(n : ℚ)) ∧ (d > 1 → G (d, n) = (d/(n : ℚ))*∑ i in Finset.Icc d n, G ((d : ℤ) - 1, (i : ℤ) - 1)))
+(hG : ∀ d n : ℕ, d ≤ n → (d = 1 → G (d, n) = 1/(n : ℚ)) ∧ (d > 1 → G (d, n) = (d/(n : ℚ))*∑ i ∈ Finset.Icc d n, G ((d : ℤ) - 1, (i : ℤ) - 1)))
 : ∀ d p : ℕ, 1 < d ∧ d ≤ p ∧ Prime p → ¬p ∣ (G (d, p)).den :=
 sorry

--- a/lean4/src/putnam_1981_a1.lean
+++ b/lean4/src/putnam_1981_a1.lean
@@ -9,7 +9,7 @@ Let $E(n)$ be the greatest integer $k$ such that $5^k$ divides $1^1 2^2 3^3 \cdo
 -/
 theorem putnam_1981_a1
     (P : ℕ → ℕ → Prop)
-    (hP : ∀ n k, P n k ↔ 5^k ∣ ∏ m in Finset.Icc 1 n, (m^m : ℤ))
+    (hP : ∀ n k, P n k ↔ 5^k ∣ ∏ m ∈ Finset.Icc 1 n, (m^m : ℤ))
     (E : ℕ → ℕ)
     (hE : ∀ n ∈ Ici 1, P n (E n) ∧ ∀ k : ℕ, P n k → k ≤ E n) :
     Tendsto (fun n : ℕ => ((E n) : ℝ)/n^2) atTop (𝓝 putnam_1981_a1_solution) :=

--- a/lean4/src/putnam_1981_b1.lean
+++ b/lean4/src/putnam_1981_b1.lean
@@ -9,6 +9,6 @@ Find the value of $$\lim_{n \rightarrow \infty} \frac{1}{n^5}\sum_{h=1}^{n}\sum_
 -/
 theorem putnam_1981_b1
 (f : ℕ → ℝ)
-(hf : f = fun n : ℕ => ((1 : ℝ)/n^5) * ∑ h in Finset.Icc 1 n, ∑ k in Finset.Icc 1 n, (5*(h : ℝ)^4 - 18*h^2*k^2 + 5*k^4))
+(hf : f = fun n : ℕ => ((1 : ℝ)/n^5) * ∑ h ∈ Finset.Icc 1 n, ∑ k ∈ Finset.Icc 1 n, (5*(h : ℝ)^4 - 18*h^2*k^2 + 5*k^4))
 : Tendsto f atTop (𝓝 putnam_1981_b1_solution) :=
 sorry

--- a/lean4/src/putnam_1982_a2.lean
+++ b/lean4/src/putnam_1982_a2.lean
@@ -9,8 +9,8 @@ Let $B_n(x) = 1^x + 2^x + \dots + n^x$ and let $f(n) = \frac{B_n(\log_n 2)}{(n \
 -/
 theorem putnam_1982_a2
 (B : ℕ → ℝ → ℝ)
-(hB : B = fun (n : ℕ) (x : ℝ) ↦ ∑ k in Finset.Icc 1 n, (k : ℝ) ^ x)
+(hB : B = fun (n : ℕ) (x : ℝ) ↦ ∑ k ∈ Finset.Icc 1 n, (k : ℝ) ^ x)
 (f : ℕ → ℝ)
 (hf : f = fun n ↦ B n (logb n 2) / (n * logb 2 n) ^ 2)
-: (∃ L : ℝ, Tendsto (fun N ↦ ∑ j in Finset.Icc 2 N, f j) atTop (𝓝 L)) ↔ putnam_1982_a2_solution :=
+: (∃ L : ℝ, Tendsto (fun N ↦ ∑ j ∈ Finset.Icc 2 N, f j) atTop (𝓝 L)) ↔ putnam_1982_a2_solution :=
 sorry

--- a/lean4/src/putnam_1982_a6.lean
+++ b/lean4/src/putnam_1982_a6.lean
@@ -22,7 +22,7 @@ theorem putnam_1982_a6 :
       BijOn b (Ici 1) (Ici 1) →
       StrictAntiOn (fun n : ℕ => |x n|) (Ici 1) →
       Tendsto (fun n : ℕ => |b n - (n : ℤ)| * |x n|) atTop (𝓝 0) →
-      Tendsto (fun n : ℕ => ∑ k in Finset.Icc 1 n, x k) atTop (𝓝 1) →
-      Tendsto (fun n : ℕ => ∑ k in Finset.Icc 1 n, x (b k)) atTop (𝓝 1))
+      Tendsto (fun n : ℕ => ∑ k ∈ Finset.Icc 1 n, x k) atTop (𝓝 1) →
+      Tendsto (fun n : ℕ => ∑ k ∈ Finset.Icc 1 n, x (b k)) atTop (𝓝 1))
   ↔ putnam_1982_a6_solution :=
 sorry

--- a/lean4/src/putnam_1982_b4.lean
+++ b/lean4/src/putnam_1982_b4.lean
@@ -15,7 +15,7 @@ If all $n_i$ are positive, then $\{n_1, n_2, \dots, n_s\} = \{1, 2, \dots, s\}$.
 -/
 theorem putnam_1982_b4
     (P : Finset ℤ → Prop)
-    (P_def : ∀ n, P n ↔ n.Nonempty ∧ ∀ k, ∏ i in n, i ∣ ∏ i ∈ n, (i + k)) :
+    (P_def : ∀ n, P n ↔ n.Nonempty ∧ ∀ k, ∏ i ∈ n, i ∣ ∏ i ∈ n, (i + k)) :
     ((∀ n, P n → 1 ∈ n ∨ -1 ∈ n) ↔ putnam_1982_b4_solution.1) ∧
     ((∀ n, P n → (∀ i ∈ n, 0 < i) → n = Finset.Icc (1 : ℤ) n.card) ↔ putnam_1982_b4_solution.2) :=
   sorry

--- a/lean4/src/putnam_1982_b4.lean
+++ b/lean4/src/putnam_1982_b4.lean
@@ -15,7 +15,7 @@ If all $n_i$ are positive, then $\{n_1, n_2, \dots, n_s\} = \{1, 2, \dots, s\}$.
 -/
 theorem putnam_1982_b4
     (P : Finset ℤ → Prop)
-    (P_def : ∀ n, P n ↔ n.Nonempty ∧ ∀ k, ∏ i in n, i ∣ ∏ i in n, (i + k)) :
+    (P_def : ∀ n, P n ↔ n.Nonempty ∧ ∀ k, ∏ i in n, i ∣ ∏ i ∈ n, (i + k)) :
     ((∀ n, P n → 1 ∈ n ∨ -1 ∈ n) ↔ putnam_1982_b4_solution.1) ∧
     ((∀ n, P n → (∀ i ∈ n, 0 < i) → n = Finset.Icc (1 : ℤ) n.card) ↔ putnam_1982_b4_solution.2) :=
   sorry

--- a/lean4/src/putnam_1983_a3.lean
+++ b/lean4/src/putnam_1983_a3.lean
@@ -7,6 +7,6 @@ theorem putnam_1983_a3
 (p : ℕ)
 (F : ℕ → ℕ)
 (poddprime : Odd p ∧ p.Prime)
-(hF : ∀ n : ℕ, F n = ∑ i in Finset.range (p - 1), (i + 1) * n ^ i)
+(hF : ∀ n : ℕ, F n = ∑ i ∈ Finset.range (p - 1), (i + 1) * n ^ i)
 : ∀ a ∈ Finset.Icc 1 p, ∀ b ∈ Finset.Icc 1 p, a ≠ b → ¬(F a ≡ F b [MOD p]) :=
 sorry

--- a/lean4/src/putnam_1983_a4.lean
+++ b/lean4/src/putnam_1983_a4.lean
@@ -13,6 +13,6 @@ theorem putnam_1983_a4
 (S : ℤ)
 (kpos : k > 0)
 (hm : m = 6 * k - 1)
-(hS : S = ∑ j in Finset.Icc 1 (2 * k - 1), (-1 : ℤ) ^ (j + 1) * choose m (3 * j - 1))
+(hS : S = ∑ j ∈ Finset.Icc 1 (2 * k - 1), (-1 : ℤ) ^ (j + 1) * choose m (3 * j - 1))
 : (S ≠ 0) :=
 sorry

--- a/lean4/src/putnam_1983_b5.lean
+++ b/lean4/src/putnam_1983_b5.lean
@@ -10,6 +10,6 @@ Define $\left\lVert x \right\rVert$ as the distance from $x$ to the nearest inte
 theorem putnam_1983_b5
 (dist_fun : ℝ → ℝ)
 (hdist_fun : dist_fun = fun (x : ℝ) ↦ min (x - ⌊x⌋) (⌈x⌉ - x))
-(fact : Tendsto (fun N ↦ ∏ n in Finset.Icc 1 N, (2 * n / (2 * n - 1)) * (2 * n / (2 * n + 1)) : ℕ → ℝ) atTop (𝓝 (Real.pi / 2)))
+(fact : Tendsto (fun N ↦ ∏ n ∈ Finset.Icc 1 N, (2 * n / (2 * n - 1)) * (2 * n / (2 * n + 1)) : ℕ → ℝ) atTop (𝓝 (Real.pi / 2)))
 : (Tendsto (fun n ↦ (1 / n) * ∫ x in (1)..n, dist_fun (n / x) : ℕ → ℝ) atTop (𝓝 putnam_1983_b5_solution)) :=
 sorry

--- a/lean4/src/putnam_1985_a5.lean
+++ b/lean4/src/putnam_1985_a5.lean
@@ -9,6 +9,6 @@ Let $I_m = \int_0^{2\pi} \cos(x)\cos(2x)\cdots \cos(mx)\,dx$. For which integers
 -/
 theorem putnam_1985_a5
     (I : ℕ → ℝ)
-    (hI : I = fun (m : ℕ) ↦ ∫ x in (0)..(2 * Real.pi), ∏ k in Finset.Icc 1 m, cos (k * x)) :
+    (hI : I = fun (m : ℕ) ↦ ∫ x in (0)..(2 * Real.pi), ∏ k ∈ Finset.Icc 1 m, cos (k * x)) :
     {m ∈ Finset.Icc 1 10 | I m ≠ 0} = putnam_1985_a5_solution :=
   sorry

--- a/lean4/src/putnam_1985_a6.lean
+++ b/lean4/src/putnam_1985_a6.lean
@@ -19,7 +19,7 @@ for every integer $n \geq 1$.
 theorem putnam_1985_a6
   (Γ : Polynomial ℝ → ℝ)
   (f : Polynomial ℝ)
-  (hΓ : Γ = fun p ↦ ∑ k in Finset.range (p.natDegree + 1), coeff p k ^ 2)
+  (hΓ : Γ = fun p ↦ ∑ k ∈ Finset.range (p.natDegree + 1), coeff p k ^ 2)
   (hf : f = 3 * X ^ 2 + 7 * X + 2) :
   let g := putnam_1985_a6_solution;
   g.eval 0 = 1 ∧ ∀ n : ℕ, n ≥ 1 → Γ (f ^ n) = Γ (g ^ n) :=

--- a/lean4/src/putnam_1985_b6.lean
+++ b/lean4/src/putnam_1985_b6.lean
@@ -11,6 +11,6 @@ theorem putnam_1985_b6
 (npos : n > 0)
 (G : Finset (Matrix (Fin n) (Fin n) ℝ))
 (groupG : (∀ g ∈ G, ∀ h ∈ G, g * h ∈ G) ∧ 1 ∈ G ∧ (∀ g ∈ G, ∃ h ∈ G, g * h = 1))
-(hG : ∑ M in G, Matrix.trace M = 0)
-: (∑ M in G, M = 0) :=
+(hG : ∑ M ∈ G, Matrix.trace M = 0)
+: (∑ M ∈ G, M = 0) :=
 sorry

--- a/lean4/src/putnam_1988_a3.lean
+++ b/lean4/src/putnam_1988_a3.lean
@@ -12,5 +12,5 @@ Determine, with proof, the set of real numbers $x$ for which
 converges.
 -/
 theorem putnam_1988_a3
-: {x : ℝ | ∃ L : ℝ, Tendsto (fun t ↦ ∑ n in Finset.Icc (1 : ℕ) t, (((1 / n) / Real.sin (1 / n) - 1) ^ x)) atTop (𝓝 L)} = putnam_1988_a3_solution :=
+: {x : ℝ | ∃ L : ℝ, Tendsto (fun t ↦ ∑ n ∈ Finset.Icc (1 : ℕ) t, (((1 / n) / Real.sin (1 / n) - 1) ^ x)) atTop (𝓝 L)} = putnam_1988_a3_solution :=
 sorry

--- a/lean4/src/putnam_1989_b3.lean
+++ b/lean4/src/putnam_1989_b3.lean
@@ -3,7 +3,7 @@ import Mathlib
 open Nat Filter Topology
 
 noncomputable abbrev putnam_1989_b3_solution : ℕ → ℝ → ℝ := sorry
--- fun n c ↦ c * n ! / (3 ^ n * ∏ m in Finset.Icc (1 : ℤ) n, (1 - 2 ^ (-m)))
+-- fun n c ↦ c * n ! / (3 ^ n * ∏ m ∈ Finset.Icc (1 : ℤ) n, (1 - 2 ^ (-m)))
 /--
 Let $f$ be a function on $[0,\infty)$, differentiable and satisfying
 \[

--- a/lean4/src/putnam_1989_b6.lean
+++ b/lean4/src/putnam_1989_b6.lean
@@ -13,7 +13,7 @@ theorem putnam_1989_b6
     (X : Set (Fin n → ℝ))
     (X_def : ∀ x, x ∈ X ↔ 0 < x 0 ∧ x (-1) < 1 ∧ ∀ i, i + 1 < n → x i < x (i + 1))
     (S : (ℝ → ℝ) → (Fin (n + 2) → ℝ) → ℝ)
-    (S_def : ∀ f x, S f x = ∑ i in Finset.Iic n, (x (i + 1) - x i) * f (i + 1)) :
+    (S_def : ∀ f x, S f x = ∑ i ∈ Finset.Iic n, (x (i + 1) - x i) * f (i + 1)) :
     ∃ P : Polynomial ℝ,
       P.degree = n ∧
       (∀ t ∈ Icc 0 1, P.eval t ∈ Icc 0 1) ∧

--- a/lean4/src/putnam_1990_b5.lean
+++ b/lean4/src/putnam_1990_b5.lean
@@ -9,6 +9,6 @@ Is there an infinite sequence $a_0,a_1,a_2,\dots$ of nonzero real numbers such t
 -/
 theorem putnam_1990_b5 :
     (∃ a : ℕ → ℝ, (∀ i, a i ≠ 0) ∧
-      (∀ n ≥ 1, (∑ i in Finset.Iic n, a i • X ^ i : Polynomial ℝ).roots.toFinset.card = n)) ↔
+      (∀ n ≥ 1, (∑ i ∈ Finset.Iic n, a i • X ^ i : Polynomial ℝ).roots.toFinset.card = n)) ↔
     putnam_1990_b5_solution :=
   sorry

--- a/lean4/src/putnam_1992_a2.lean
+++ b/lean4/src/putnam_1992_a2.lean
@@ -13,5 +13,5 @@ Define $C(\alpha)$ to be the coefficient of $x^{1992}$ in the power series about
 theorem putnam_1992_a2
 (C : ℝ → ℝ)
 (hC : C = fun α ↦ taylorCoeffWithin (fun x ↦ (1 + x) ^ α) 1992 Set.univ 0)
-: (∫ y in (0)..1, C (-y - 1) * ∑ k in Finset.Icc (1 : ℕ) 1992, 1 / (y + k) = putnam_1992_a2_solution) :=
+: (∫ y in (0)..1, C (-y - 1) * ∑ k ∈ Finset.Icc (1 : ℕ) 1992, 1 / (y + k) = putnam_1992_a2_solution) :=
 sorry

--- a/lean4/src/putnam_1992_b2.lean
+++ b/lean4/src/putnam_1992_b2.lean
@@ -13,5 +13,5 @@ theorem putnam_1992_b2
     (Q : ℕ → ℕ → ℕ)
     (hQ : Q = fun n k ↦ coeff ((1 + X + X ^ 2 + X ^ 3) ^ n) k)
     (n k : ℕ) :
-    Q n k = ∑ j in Finset.Iic k, choose n j * (if 2 * j ≤ k then choose n (k - 2 * j) else 0) :=
+    Q n k = ∑ j ∈ Finset.Iic k, choose n j * (if 2 * j ≤ k then choose n (k - 2 * j) else 0) :=
   sorry

--- a/lean4/src/putnam_1996_a5.lean
+++ b/lean4/src/putnam_1996_a5.lean
@@ -11,5 +11,5 @@ theorem putnam_1996_a5
 (hpge3 : p > 3)
 (k : ℕ)
 (hk : k = Nat.floor (2*p/(3 : ℚ)))
-: p^2 ∣ ∑ i in Finset.Icc 1 k, Nat.choose p i :=
+: p^2 ∣ ∑ i ∈ Finset.Icc 1 k, Nat.choose p i :=
 sorry

--- a/lean4/src/putnam_1996_b2.lean
+++ b/lean4/src/putnam_1996_b2.lean
@@ -9,6 +9,6 @@ theorem putnam_1996_b2
 (n : ℕ)
 (prododd : ℝ)
 (npos : n > 0)
-(hprododd : prododd = ∏ i in Finset.range (2 * n), if Odd i then i else 1)
+(hprododd : prododd = ∏ i ∈ Finset.range (2 * n), if Odd i then i else 1)
 : ((2 * n - 1 : ℝ) / Real.exp 1) ^ ((2 * n - 1 : ℝ) / 2) < prododd ∧ prododd < ((2 * n + 1 : ℝ) / Real.exp 1) ^ ((2 * n + 1 : ℝ) / 2) :=
 sorry

--- a/lean4/src/putnam_1996_b5.lean
+++ b/lean4/src/putnam_1996_b5.lean
@@ -12,7 +12,7 @@ theorem putnam_1996_b5
     (n : ℕ)
     (Δ : (Fin n → ℤˣ) → Fin n → Fin n → ℤ)
     (balanced : (Fin n → ℤˣ) → Prop)
-    (hΔ : ∀ S, ∀ a b, a ≤ b → Δ S a b = ∑ i in Finset.Icc a b, (S i : ℤ))
+    (hΔ : ∀ S, ∀ a b, a ≤ b → Δ S a b = ∑ i ∈ Finset.Icc a b, (S i : ℤ))
     (hbalanced : ∀ S, balanced S ↔ ∀ a b, a ≤ b → |Δ S a b| ≤ 2) :
     {S : Fin n → ℤˣ | balanced S}.ncard = putnam_1996_b5_solution n :=
   sorry

--- a/lean4/src/putnam_1997_b1.lean
+++ b/lean4/src/putnam_1997_b1.lean
@@ -10,6 +10,6 @@ Let $\{x\}$ denote the distance between the real number $x$ and the nearest inte
 -/
 theorem putnam_1997_b1
 (F : ℕ → ℝ)
-(hF : F = fun (n : ℕ) => ∑ m in Finset.Icc 1 (6 * n - 1), min (dist_to_int (m/(6*n)) ) (dist_to_int (m/(3*n))))
+(hF : F = fun (n : ℕ) => ∑ m ∈ Finset.Icc 1 (6 * n - 1), min (dist_to_int (m/(6*n)) ) (dist_to_int (m/(3*n))))
 : ∀ n, n > 0 → F n = putnam_1997_b1_solution n :=
 sorry

--- a/lean4/src/putnam_1997_b3.lean
+++ b/lean4/src/putnam_1997_b3.lean
@@ -10,5 +10,5 @@ For each positive integer $n$, write the sum $\sum_{m=1}^n 1/m$ in the form $p_n
 theorem putnam_1997_b3
 (n : ℕ)
 (hn : n > 0)
-: n ∈ putnam_1997_b3_solution ↔ ¬5 ∣ (∑ m in Finset.Icc 1 n, 1/m : ℚ).den :=
+: n ∈ putnam_1997_b3_solution ↔ ¬5 ∣ (∑ m ∈ Finset.Icc 1 n, 1/m : ℚ).den :=
 sorry

--- a/lean4/src/putnam_1997_b4.lean
+++ b/lean4/src/putnam_1997_b4.lean
@@ -9,5 +9,5 @@ theorem putnam_1997_b4
     (a : ℕ → ℕ → ℤ)
     (ha : ∀ m n, a m n = coeff ((1 + X + X ^ 2) ^ m) n)
     (k : ℕ) :
-    (∑ i in Finset.Iic ⌊2 * (k : ℚ) / 3⌋₊, (-1) ^ i * a (k - i) i) ∈ Icc 0 1 :=
+    (∑ i ∈ Finset.Iic ⌊2 * (k : ℚ) / 3⌋₊, (-1) ^ i * a (k - i) i) ∈ Icc 0 1 :=
   sorry

--- a/lean4/src/putnam_1998_b4.lean
+++ b/lean4/src/putnam_1998_b4.lean
@@ -9,7 +9,7 @@ Find necessary and sufficient conditions on positive integers $m$ and $n$ so tha
 -/
 theorem putnam_1998_b4
   (quantity : ℕ → ℕ → ℤ)
-  (hquantity : quantity = fun n m => ∑ i in Finset.range (m * n), (-1)^(i/m + i/n))
+  (hquantity : quantity = fun n m => ∑ i ∈ Finset.range (m * n), (-1)^(i/m + i/n))
   (n m : ℕ)
   (hnm : n > 0 ∧ m > 0) :
   quantity n m = 0 ↔ ⟨n, m⟩ ∈ putnam_1998_b4_solution :=

--- a/lean4/src/putnam_1998_b5.lean
+++ b/lean4/src/putnam_1998_b5.lean
@@ -9,6 +9,6 @@ Let $N$ be the positive integer with 1998 decimal digits, all of them 1; that is
 -/
 theorem putnam_1998_b5
 (N : ℕ)
-(hN : N = ∑ i in Finset.range 1998, 10^i)
+(hN : N = ∑ i ∈ Finset.range 1998, 10^i)
 : putnam_1998_b5_solution = (Nat.floor (10^1000 * Real.sqrt N)) % 10 :=
 sorry

--- a/lean4/src/putnam_1999_a3.lean
+++ b/lean4/src/putnam_1999_a3.lean
@@ -9,7 +9,7 @@ theorem putnam_1999_a3
     (f : ℝ → ℝ)
     (hf : f = fun x ↦ 1 / (1 - 2 * x - x ^ 2))
     (a : ℕ → ℝ)
-    (hf' : ∀ᶠ x in 𝓝 0, Tendsto (fun N : ℕ ↦ ∑ n in Finset.range N, (a n) * x ^ n) atTop (𝓝 (f x)))
+    (hf' : ∀ᶠ x in 𝓝 0, Tendsto (fun N : ℕ ↦ ∑ n ∈ Finset.range N, (a n) * x ^ n) atTop (𝓝 (f x)))
     (n : ℕ) :
     ∃ m : ℕ, (a n) ^ 2 + (a (n + 1)) ^ 2 = a m :=
   sorry

--- a/lean4/src/putnam_1999_a4.lean
+++ b/lean4/src/putnam_1999_a4.lean
@@ -9,5 +9,5 @@ noncomputable abbrev putnam_1999_a4_solution : ℝ := sorry
 Sum the series \[\sum_{m=1}^\infty \sum_{n=1}^\infty \frac{m^2 n}{3^m(n3^m+m3^n)}.\]
 -/
 theorem putnam_1999_a4
-: Tendsto (fun i => ∑ m in Finset.range i, ∑' n : ℕ, (((m + 1)^2*(n+1))/(3^(m + 1) * ((n+1)*3^(m + 1) + (m + 1)*3^(n+1))) : ℝ)) atTop (𝓝 putnam_1999_a4_solution) :=
+: Tendsto (fun i => ∑ m ∈ Finset.range i, ∑' n : ℕ, (((m + 1)^2*(n+1))/(3^(m + 1) * ((n+1)*3^(m + 1) + (m + 1)*3^(n+1))) : ℝ)) atTop (𝓝 putnam_1999_a4_solution) :=
 sorry

--- a/lean4/src/putnam_2002_a6.lean
+++ b/lean4/src/putnam_2002_a6.lean
@@ -16,5 +16,5 @@ converge?
 theorem putnam_2002_a6
 (f : ℕ → ℕ → ℝ)
 (hf : ∀ b : ℕ, f b 1 = 1 ∧ f b 2 = 2 ∧ ∀ n ∈ Ici 3, f b n = n * f b (Nat.digits b n).length)
-: {b ∈ Ici 2 | ∃ L : ℝ, Tendsto (fun m : ℕ => ∑ n in Finset.Icc 1 m, 1/(f b n)) atTop (𝓝 L)} = putnam_2002_a6_solution :=
+: {b ∈ Ici 2 | ∃ L : ℝ, Tendsto (fun m : ℕ => ∑ n ∈ Finset.Icc 1 m, 1/(f b n)) atTop (𝓝 L)} = putnam_2002_a6_solution :=
 sorry

--- a/lean4/src/putnam_2002_b6.lean
+++ b/lean4/src/putnam_2002_b6.lean
@@ -23,5 +23,5 @@ theorem putnam_2002_b6
 (hM : M = fun (r c : Fin 3) => ((X c)^(p^(r : ℕ)) : MvPolynomial (Fin 3) ℤ))
 (cong : ℕ → MvPolynomial (Fin 3) ℤ × MvPolynomial (Fin 3) ℤ → Prop)
 (hcong : cong = fun p : ℕ => fun (f, g) => ∀ n : Fin 3 →₀ ℕ, Int.ModEq p (f.coeff n) (g.coeff n))
-: ∃ S : Finset (MvPolynomial (Fin 3) ℤ), cong p ((det M), (∏ s in S, s)) ∧ ∀ s ∈ S, (∃ a b c : ℤ, s = (C a)*(X 0) + (C b)*(X 1) + (C c)*(X 2)) :=
+: ∃ S : Finset (MvPolynomial (Fin 3) ℤ), cong p ((det M), (∏ s ∈ S, s)) ∧ ∀ s ∈ S, (∃ a b c : ℤ, s = (C a)*(X 0) + (C b)*(X 1) + (C c)*(X 2)) :=
 sorry

--- a/lean4/src/putnam_2003_b3.lean
+++ b/lean4/src/putnam_2003_b3.lean
@@ -6,5 +6,5 @@ open MvPolynomial Set Nat
 Show that for each positive integer $n$, $n!=\prod_{i=1}^n \text{lcm}\{1,2,\dots,\lfloor n/i \rfloor\}$. (Here lcm denotes the least common multiple, and $\lfloor x \rfloor$ denotes the greatest integer $\leq x$.)
 -/
 theorem putnam_2003_b3 (n : ℕ) :
-    n ! = ∏ i in Finset.Icc 1 n, ((List.range ⌊n / i⌋₊).map succ).foldl Nat.lcm 1 :=
+    n ! = ∏ i ∈ Finset.Icc 1 n, ((List.range ⌊n / i⌋₊).map succ).foldl Nat.lcm 1 :=
   sorry

--- a/lean4/src/putnam_2004_b1.lean
+++ b/lean4/src/putnam_2004_b1.lean
@@ -11,5 +11,5 @@ theorem putnam_2004_b1
 (r : ℚ)
 (Pdeg : P.degree = n)
 (Preq0 : Polynomial.aeval r P = 0)
-: ∀ i ∈ Finset.range n, ∃ m : ℤ, m = ∑ j in Finset.range (i + 1), (P.coeff (n - j) * r ^ (i + 1 - j)) :=
+: ∀ i ∈ Finset.range n, ∃ m : ℤ, m = ∑ j ∈ Finset.range (i + 1), (P.coeff (n - j) * r ^ (i + 1 - j)) :=
 sorry

--- a/lean4/src/putnam_2004_b5.lean
+++ b/lean4/src/putnam_2004_b5.lean
@@ -10,7 +10,7 @@ Evaluate $\lim_{x \to 1^-} \prod_{n=0}^\infty \left(\frac{1+x^{n+1}}{1+x^n}\righ
 theorem putnam_2004_b5
     (xprod : ℝ → ℝ)
     (hxprod : ∀ x ∈ Set.Ioo 0 1,
-      Tendsto (fun N ↦ ∏ n in Finset.range N, ((1 + x ^ (n + 1)) / (1 + x ^ n)) ^ (x ^ n))
+      Tendsto (fun N ↦ ∏ n ∈ Finset.range N, ((1 + x ^ (n + 1)) / (1 + x ^ n)) ^ (x ^ n))
       atTop (𝓝 (xprod x))) :
     Tendsto xprod (𝓝[<] 1) (𝓝 putnam_2004_b5_solution) :=
   sorry

--- a/lean4/src/putnam_2005_a3.lean
+++ b/lean4/src/putnam_2005_a3.lean
@@ -11,9 +11,9 @@ theorem putnam_2005_a3
     (hn : 0 < n)
     (g : ℂ → ℂ)
     (pdeg : p.degree = n)
-    (pzeros : ∀ z : ℂ, p.eval z = 0 → Complex.abs z = 1)
+    (pzeros : ∀ z : ℂ, p.eval z = 0 → ‖z‖ = 1)
     (hg : ∀ z : ℂ, g z = (p.eval z) / z ^ ((n : ℂ) / 2))
     (z : ℂ)
     (hz : z ≠ 0 ∧ deriv g z = 0) :
-    Complex.abs z = 1 :=
+    ‖z‖ = 1 :=
   sorry

--- a/lean4/src/putnam_2005_b2.lean
+++ b/lean4/src/putnam_2005_b2.lean
@@ -9,5 +9,5 @@ abbrev putnam_2005_b2_solution : Set (ℕ × (ℕ → ℤ)) := sorry
 Find all positive integers $n,k_1,\dots,k_n$ such that $k_1+\cdots+k_n=5n-4$ and $\frac{1}{k_1}+\cdots+\frac{1}{k_n}=1$.
 -/
 theorem putnam_2005_b2
-: {((n : ℕ), (k : ℕ → ℤ)) | (n > 0) ∧ (∀ i ∈ Finset.range n, k i > 0) ∧ (∑ i in Finset.range n, k i = 5 * n - 4) ∧ (∑ i : Finset.range n, (1 : ℝ) / (k i) = 1)} = putnam_2005_b2_solution :=
+: {((n : ℕ), (k : ℕ → ℤ)) | (n > 0) ∧ (∀ i ∈ Finset.range n, k i > 0) ∧ (∑ i ∈ Finset.range n, k i = 5 * n - 4) ∧ (∑ i : Finset.range n, (1 : ℝ) / (k i) = 1)} = putnam_2005_b2_solution :=
 sorry

--- a/lean4/src/putnam_2006_b2.lean
+++ b/lean4/src/putnam_2006_b2.lean
@@ -11,5 +11,5 @@ theorem putnam_2006_b2
 (npos : n > 0)
 (X : Finset ℝ)
 (hXcard : X.card = n)
-: (∃ S ⊆ X, S ≠ ∅ ∧ ∃ m : ℤ, |m + ∑ s in S, s| ≤ 1 / (n + 1)) :=
+: (∃ S ⊆ X, S ≠ ∅ ∧ ∃ m : ℤ, |m + ∑ s ∈ S, s| ≤ 1 / (n + 1)) :=
 sorry

--- a/lean4/src/putnam_2008_a4.lean
+++ b/lean4/src/putnam_2008_a4.lean
@@ -10,5 +10,5 @@ Define $f : \mathbb{R} \to \mathbb{R} by $f(x) = x$ if $x \leq e$ and $f(x) = x 
 theorem putnam_2008_a4
 (f : ℝ → ℝ)
 (hf : f = fun x => if x ≤ Real.exp 1 then x else x * (f (Real.log x)))
-: (∃ r : ℝ, Tendsto (fun N : ℕ => ∑ n in Finset.range N, 1/(f (n + 1))) atTop (𝓝 r)) ↔ putnam_2008_a4_solution :=
+: (∃ r : ℝ, Tendsto (fun N : ℕ => ∑ n ∈ Finset.range N, 1/(f (n + 1))) atTop (𝓝 r)) ↔ putnam_2008_a4_solution :=
 sorry

--- a/lean4/src/putnam_2009_b2.lean
+++ b/lean4/src/putnam_2009_b2.lean
@@ -8,5 +8,5 @@ abbrev putnam_2009_b2_solution : Set ℝ := sorry
 A game involves jumping to the right on the real number line. If $a$ and $b$ are real numbers and $b > a$, the cost of jumping from $a$ to $b$ is $b^3-ab^2$. For what real numbers $c$ can one travel from $0$ to $1$ in a finite number of jumps with total cost exactly $c$?
 -/
 theorem putnam_2009_b2
-: ({c : ℝ | ∃ s : ℕ → ℝ, s 0 = 0 ∧ StrictMono s ∧ (∃ n : ℕ, s n = 1 ∧ ((∑ i in Finset.range n, ((s (i + 1)) ^ 3 - (s i) * (s (i + 1)) ^ 2)) = c))} = putnam_2009_b2_solution) :=
+: ({c : ℝ | ∃ s : ℕ → ℝ, s 0 = 0 ∧ StrictMono s ∧ (∃ n : ℕ, s n = 1 ∧ ((∑ i ∈ Finset.range n, ((s (i + 1)) ^ 3 - (s i) * (s (i + 1)) ^ 2)) = c))} = putnam_2009_b2_solution) :=
 sorry

--- a/lean4/src/putnam_2010_a1.lean
+++ b/lean4/src/putnam_2010_a1.lean
@@ -11,7 +11,7 @@ theorem putnam_2010_a1
     (npos : n > 0)
     (hkboxes : ∀ k : ℕ, kboxes k =
       (∃ boxes : Finset.Icc 1 n → Fin k, ∀ i j : Fin k,
-        ∑ x in Finset.univ.filter (boxes · = i), (x : ℕ) =
-        ∑ x in Finset.univ.filter (boxes · = j), (x : ℕ))) :
+        ∑ x ∈ Finset.univ.filter (boxes · = i), (x : ℕ) =
+        ∑ x ∈ Finset.univ.filter (boxes · = j), (x : ℕ))) :
     IsGreatest kboxes (putnam_2010_a1_solution n) :=
   sorry

--- a/lean4/src/putnam_2013_a6.lean
+++ b/lean4/src/putnam_2013_a6.lean
@@ -30,6 +30,6 @@ theorem putnam_2013_a6
   (hwn4 : w 0 (-1) = -4 ∧ w (-1) 0 = -4 ∧ w 1 0 = -4 ∧ w 0 1 = -4)
   (hw12 : w 0 0 = 12)
   (hw0 : ∀ a b : ℤ, (|a| > 2 ∨ |b| > 2) → w a b = 0)
-  (hA : ∀ S, A S = ∑ s in S, ∑ s' in S, w (s - s').1 (s - s').2) :
+  (hA : ∀ S, A S = ∑ s ∈ S, ∑ s' ∈ S, w (s - s').1 (s - s').2) :
   ∀ S : Finset (ℤ × ℤ), Nonempty S → A S > 0 :=
 sorry

--- a/lean4/src/putnam_2013_b2.lean
+++ b/lean4/src/putnam_2013_b2.lean
@@ -25,6 +25,6 @@ theorem putnam_2013_b2
     {f : ℝ → ℝ |
       (∀ x : ℝ, f x ≥ 0) ∧
       ∃ a : List ℝ, a.length = N + 1 ∧ (∀ n : Fin (N + 1), 3 ∣ (n : ℕ) → a[n]! = 0) ∧
-      ∀ x : ℝ, f x = 1 + ∑ n in Finset.Icc 1 N, a[(n : ℕ)]! * Real.cos (2*Real.pi*n*x)}) :
+      ∀ x : ℝ, f x = 1 + ∑ n ∈ Finset.Icc 1 N, a[(n : ℕ)]! * Real.cos (2*Real.pi*n*x)}) :
   IsGreatest {f 0 | f ∈ ⋃ N ∈ Ici 1, CN N} putnam_2013_b2_solution :=
 sorry

--- a/lean4/src/putnam_2013_b3.lean
+++ b/lean4/src/putnam_2013_b3.lean
@@ -12,6 +12,6 @@ theorem putnam_2013_b3
       P ≠ ⊥ → (∀ S ∈ P, ∀ S' ∈ P, S ∪ S' ∈ P ∧ S ∩ S' ∈ P) →
       (∀ S ∈ P, S ≠ ⊥ → ∃ T ∈ P, T ⊂ S ∧ Finset.card T + 1 = Finset.card S) →
       f ⊥ = 0 → (∀ S ∈ P, ∀ S' ∈ P, f (S ∪ S') = f S + f S' - f (S ∩ S')) →
-      ∃ r : Fin n → ℝ, ∀ S ∈ P, f S = ∑ i in S, r i)
+      ∃ r : Fin n → ℝ, ∀ S ∈ P, f S = ∑ i ∈ S, r i)
       ↔ putnam_2013_b3_solution :=
 sorry

--- a/lean4/src/putnam_2014_a3.lean
+++ b/lean4/src/putnam_2014_a3.lean
@@ -11,5 +11,5 @@ theorem putnam_2014_a3
 (a : ℕ → ℝ)
 (a0 : a 0 = 5 / 2)
 (ak : ∀ k ≥ 1, a k = (a (k - 1)) ^ 2 - 2)
-: Tendsto (fun n : ℕ => ∏ k in Finset.range n, (1 - 1 / a k)) atTop (𝓝 putnam_2014_a3_solution) :=
+: Tendsto (fun n : ℕ => ∏ k ∈ Finset.range n, (1 - 1 / a k)) atTop (𝓝 putnam_2014_a3_solution) :=
 sorry

--- a/lean4/src/putnam_2014_a5.lean
+++ b/lean4/src/putnam_2014_a5.lean
@@ -7,6 +7,6 @@ Let \[ P_n(x) = 1 + 2 x  + 3 x^2 + \cdots + n x^{n-1}.\] Prove that the polynomi
 -/
 theorem putnam_2014_a5
 (P : ℕ → Polynomial ℂ)
-(hP : ∀ n, P n = ∑ i in Finset.Icc 1 n, i * Polynomial.X ^ (i - 1))
+(hP : ∀ n, P n = ∑ i ∈ Finset.Icc 1 n, i * Polynomial.X ^ (i - 1))
 : ∀ (j k : ℕ), (j > 0 ∧ k > 0) → j ≠ k → IsCoprime (P j) (P k) :=
 sorry

--- a/lean4/src/putnam_2015_b6.lean
+++ b/lean4/src/putnam_2015_b6.lean
@@ -10,6 +10,6 @@ For each positive integer $k$, let $A(k)$ be the number of odd divisors of $k$ i
 theorem putnam_2015_b6
     (A : ℕ → ℕ)
     (hA : ∀ k > 0, A k = {j : ℕ | Odd j ∧ j ∣ k ∧ j < Real.sqrt (2 * k)}.encard) :
-    Tendsto (fun K : ℕ ↦ ∑ k in Finset.Icc 1 K, (-1 : ℝ) ^ ((k : ℝ) - 1) * (A k / (k : ℝ)))
+    Tendsto (fun K : ℕ ↦ ∑ k ∈ Finset.Icc 1 K, (-1 : ℝ) ^ ((k : ℝ) - 1) * (A k / (k : ℝ)))
       atTop (𝓝 putnam_2015_b6_solution) :=
   sorry

--- a/lean4/src/putnam_2017_a4.lean
+++ b/lean4/src/putnam_2017_a4.lean
@@ -10,5 +10,5 @@ theorem putnam_2017_a4
 (score : Fin (2 * N) → Fin 11)
 (hsurj : ∀ k : Fin 11, ∃ i : Fin (2 * N), score i = k)
 (havg : (∑ i : Fin (2 * N), (score i : ℝ)) / (2 * N) = 7.4)
-: (∃ s : Finset (Fin (2 * N)), s.card = N ∧ (∑ i in s, (score i : ℝ)) / N = 7.4 ∧ (∑ i in sᶜ, (score i : ℝ)) / N = 7.4) :=
+: (∃ s : Finset (Fin (2 * N)), s.card = N ∧ (∑ i ∈ s, (score i : ℝ)) / N = 7.4 ∧ (∑ i ∈ sᶜ, (score i : ℝ)) / N = 7.4) :=
 sorry

--- a/lean4/src/putnam_2017_b2.lean
+++ b/lean4/src/putnam_2017_b2.lean
@@ -15,7 +15,7 @@ theorem putnam_2017_b2
   (S : ℤ → ℕ → ℤ)
   (p : ℤ → ℕ → Prop)
   (q : ℤ → Prop)
-  (hS : S = fun (a : ℤ) k ↦ ∑ i in Finset.range k, (a + i))
+  (hS : S = fun (a : ℤ) k ↦ ∑ i ∈ Finset.range k, (a + i))
   (hp : ∀ N k, p N k ↔ ∃ a > 0, S a k = N)
   (hq : ∀ N, q N ↔ p N 2017 ∧ ∀ k : ℕ, k > 1 → k ≠ 2017 → ¬p N k) :
   IsLeast {a : ℤ | q (S a 2017)} putnam_2017_b2_solution :=

--- a/lean4/src/putnam_2018_b1.lean
+++ b/lean4/src/putnam_2018_b1.lean
@@ -13,6 +13,6 @@ theorem putnam_2018_b1
 (hPvdiff : Pvdiff = P \ ({v} : Finset (Fin 2 → ℤ)))
 : (v ∈ P ∧ (∃ Q R : Finset (Fin 2 → ℤ),
     (Q ∪ R = Pvdiff) ∧ (Q ∩ R = ∅) ∧ (Q.card = R.card) ∧
-    (∑ q in Q, q 0 = ∑ r in R, r 0) ∧ (∑ q in Q, q 1 = ∑ r in R, r 1)))
+    (∑ q ∈ Q, q 0 = ∑ r ∈ R, r 0) ∧ (∑ q ∈ Q, q 1 = ∑ r ∈ R, r 1)))
   ↔ v ∈ putnam_2018_b1_solution :=
 sorry

--- a/lean4/src/putnam_2018_b2.lean
+++ b/lean4/src/putnam_2018_b2.lean
@@ -7,6 +7,6 @@ theorem putnam_2018_b2
 (n : ℕ)
 (hn : n > 0)
 (f : ℕ → ℂ → ℂ)
-(hf : ∀ z : ℂ, f n z = ∑ i in Finset.range n, (n - i) * z^i)
+(hf : ∀ z : ℂ, f n z = ∑ i ∈ Finset.range n, (n - i) * z^i)
 : ∀ z : ℂ, ‖z‖ ≤ 1 → f n z ≠ 0 :=
 sorry

--- a/lean4/src/putnam_2020_a1.lean
+++ b/lean4/src/putnam_2020_a1.lean
@@ -6,5 +6,5 @@ abbrev putnam_2020_a1_solution : ℕ := sorry
 Find the number of positive integers $N$ satisfying: (i) $N$ is divisible by $2020$, (ii) $N$ has at most $2020$ decimal digits, (iii) The decimal digits of $N$ are a string of consecutive ones followed by a string of consecutive zeros.
 -/
 theorem putnam_2020_a1
-: Set.ncard {x : ℕ | (2020 ∣ x) ∧ (Nat.log 10 x) + 1 ≤ 2020 ∧ (∃ k l, k ≥ l ∧ x = ∑ i in Finset.range (k-l+1), 10 ^ (i+l))} = putnam_2020_a1_solution :=
+: Set.ncard {x : ℕ | (2020 ∣ x) ∧ (Nat.log 10 x) + 1 ≤ 2020 ∧ (∃ k l, k ≥ l ∧ x = ∑ i ∈ Finset.range (k-l+1), 10 ^ (i+l))} = putnam_2020_a1_solution :=
 sorry

--- a/lean4/src/putnam_2020_a2.lean
+++ b/lean4/src/putnam_2020_a2.lean
@@ -10,5 +10,5 @@ Let $k$ be a nonnegative integer. Evaluate
 -/
 theorem putnam_2020_a2
 (k : ℕ)
-: (∑ j in Finset.Icc 0 k, 2 ^ (k - j) * Nat.choose (k + j) j = putnam_2020_a2_solution k) :=
+: (∑ j ∈ Finset.Icc 0 k, 2 ^ (k - j) * Nat.choose (k + j) j = putnam_2020_a2_solution k) :=
 sorry

--- a/lean4/src/putnam_2020_a3.lean
+++ b/lean4/src/putnam_2020_a3.lean
@@ -15,5 +15,5 @@ theorem putnam_2020_a3
   (a : ℕ → ℝ)
   (ha0 : a 0 = Real.pi / 2)
   (ha : ∀ n, a (n+1) = Real.sin (a n)) :
-  (∃ L, Tendsto (fun m : ℕ => ∑ n in Finset.Icc 1 m, (a n)^2) atTop (𝓝 L)) ↔ putnam_2020_a3_solution :=
+  (∃ L, Tendsto (fun m : ℕ => ∑ n ∈ Finset.Icc 1 m, (a n)^2) atTop (𝓝 L)) ↔ putnam_2020_a3_solution :=
 sorry

--- a/lean4/src/putnam_2020_a6.lean
+++ b/lean4/src/putnam_2020_a6.lean
@@ -14,6 +14,6 @@ Determine the smallest constant $M$ such that $f_N(x) \leq M$ for all $N$ and al
 theorem putnam_2020_a6
   (f : ℤ → (ℝ → ℝ))
   (hf : f = fun N : ℤ => fun x : ℝ =>
-    ∑ n in Finset.Icc 0 N, (N + 1/2 - n)/((N + 1)*(2*n + 1)) * Real.sin ((2*n + 1)*x))
+    ∑ n ∈ Finset.Icc 0 N, (N + 1/2 - n)/((N + 1)*(2*n + 1)) * Real.sin ((2*n + 1)*x))
   : putnam_2020_a6_solution = sSup {y | ∃ᵉ (N > 0) (x : ℝ), y = f N x} :=
 sorry

--- a/lean4/src/putnam_2020_b4.lean
+++ b/lean4/src/putnam_2020_b4.lean
@@ -12,7 +12,7 @@ theorem putnam_2020_b4
 (q : ℕ → (ℕ → ℤ) → ℝ)
 (M : ℕ → ℝ)
 (hV : V = fun n ↦ ({s : ℕ → ℤ | s 0 = 0 ∧ (∀ j ≥ 2 * n, s j = 0) ∧ (∀ j ∈ Icc 1 (2 * n), |s j - s (j - 1)| = 1)}))
-(hq : q = fun n s ↦ 1 + ∑ j in Finset.Icc 1 (2 * n - 1), 3 ^ (s j))
+(hq : q = fun n s ↦ 1 + ∑ j ∈ Finset.Icc 1 (2 * n - 1), 3 ^ (s j))
 (hM : M = fun n ↦ (∑' v : V n, 1 / (q n v)) / (V n).ncard)
 : (M 2020 = putnam_2020_b4_solution) :=
 sorry

--- a/lean4/src/putnam_2020_b6.lean
+++ b/lean4/src/putnam_2020_b6.lean
@@ -8,5 +8,5 @@ Let $n$ be a positive integer. Prove that $\sum_{k=1}^n(-1)^{\lfloor k(\sqrt{2}-
 theorem putnam_2020_b6
 (n : ℕ)
 (npos : n > 0)
-: ∑ k in Finset.Icc 1 n, ((-1) ^ Int.floor (k * (Real.sqrt 2 - 1)) : ℝ) ≥ 0 :=
+: ∑ k ∈ Finset.Icc 1 n, ((-1) ^ Int.floor (k * (Real.sqrt 2 - 1)) : ℝ) ≥ 0 :=
 sorry

--- a/lean4/src/putnam_2021_a5.lean
+++ b/lean4/src/putnam_2021_a5.lean
@@ -12,6 +12,6 @@ theorem putnam_2021_a5
   (A : Finset ℕ)
   (S : ℕ → ℕ)
   (hA : A = {n | 1 ≤ n ∧ n ≤ 2021 ∧ Nat.gcd n 2021 = 1})
-  (hS : ∀ j' : ℕ, S j' = ∑ n in A, n ^ j') :
+  (hS : ∀ j' : ℕ, S j' = ∑ n ∈ A, n ^ j') :
   (2021 ∣ S j) ↔ j ∈ putnam_2021_a5_solution :=
 sorry

--- a/lean4/src/putnam_2021_b2.lean
+++ b/lean4/src/putnam_2021_b2.lean
@@ -10,6 +10,6 @@ Determine the maximum value of the sum $S = \sum_{n=1}^\infty \frac{n}{2^n}(a_1a
 theorem putnam_2021_b2 :
     IsGreatest
       {S | ∃ a : ℕ+ → ℝ, (∑' k, a k = 1) ∧ (∀ k, 0 ≤ a k) ∧
-        S = ∑' n : ℕ+, n / 2 ^ (n : ℕ) * (∏ k in Finset.Icc 1 n, a k) ^ (1 / n : ℝ)}
+        S = ∑' n : ℕ+, n / 2 ^ (n : ℕ) * (∏ k ∈ Finset.Icc 1 n, a k) ^ (1 / n : ℝ)}
       putnam_2021_b2_solution :=
   sorry

--- a/lean4/src/putnam_2022_a2.lean
+++ b/lean4/src/putnam_2022_a2.lean
@@ -13,6 +13,6 @@ theorem putnam_2022_a2
 (S : Set ℝ[X])
 (hS : S = {P | natDegree P = n})
 (negs : ℝ[X] → ℕ)
-(hnegs : ∀ P : ℝ[X], negs P = ∑ i in Finset.range (P.natDegree + 1), if P.coeff i < 0 then 1 else 0)
+(hnegs : ∀ P : ℝ[X], negs P = ∑ i ∈ Finset.range (P.natDegree + 1), if P.coeff i < 0 then 1 else 0)
 : sSup {negs (P^2) | P ∈ S} = putnam_2022_a2_solution n :=
 sorry

--- a/lean4/src/putnam_2022_a6.lean
+++ b/lean4/src/putnam_2022_a6.lean
@@ -13,6 +13,6 @@ theorem putnam_2022_a6
     IsGreatest
       {m : ℕ | ∃ x : ℕ → ℝ,
         StrictMono x ∧ -1 < x 1 ∧ x (2 * n) < 1 ∧
-        ∀ k ∈ Icc 1 m, ∑ i in Icc 1 n, ((x (2 * i) : ℝ) ^ (2 * k - 1) - (x (2 * i - 1)) ^ (2 * k - 1)) = 1}
+        ∀ k ∈ Icc 1 m, ∑ i ∈ Icc 1 n, ((x (2 * i) : ℝ) ^ (2 * k - 1) - (x (2 * i - 1)) ^ (2 * k - 1)) = 1}
     (putnam_2022_a6_solution n) :=
   sorry

--- a/lean4/src/putnam_2023_a1.lean
+++ b/lean4/src/putnam_2023_a1.lean
@@ -9,6 +9,6 @@ For a positive integer $n$, let $f_n(x) = \cos(x) \cos(2x) \cos(3x) \cdots \cos(
 -/
 theorem putnam_2023_a1
   (f : ℕ → ℝ → ℝ)
-  (hf : ∀ n > 0, f n = fun x : ℝ => ∏ i in Finset.Icc 1 n, Real.cos (i * x)) :
+  (hf : ∀ n > 0, f n = fun x : ℝ => ∏ i ∈ Finset.Icc 1 n, Real.cos (i * x)) :
   IsLeast {n | 0 < n ∧ |iteratedDeriv 2 (f n) 0| > 2023} putnam_2023_a1_solution :=
 sorry

--- a/lean4/src/putnam_2023_a5.lean
+++ b/lean4/src/putnam_2023_a5.lean
@@ -11,5 +11,5 @@ abbrev putnam_2023_a5_solution : Set ℂ := sorry
 For a nonnegative integer $k$, let $f(k)$ be the number of ones in the base 3 representation of $k$. Find all complex numbers $z$ such that \[ \sum_{k=0}^{3^{1010}-1} (-2)^{f(k)} (z+k)^{2023} = 0. \]
 -/
 theorem putnam_2023_a5
-: {z : ℂ | ∑ k in Finset.Icc 0 (3^1010 - 1), (-2)^(num_ones (digits 3 k)) * (z + k)^2023 = 0} = putnam_2023_a5_solution :=
+: {z : ℂ | ∑ k ∈ Finset.Icc 0 (3^1010 - 1), (-2)^(num_ones (digits 3 k)) * (z + k)^2023 = 0} = putnam_2023_a5_solution :=
 sorry


### PR DESCRIPTION
The big operator notation changed upstream, and `Complex.abs` is now deprecated in favor of the more general `norm`.