### PR TITLE
Remove `Nat.cast` from `Fin`, in preparation for a Lean upgrade

### DIFF
--- a/lean4/src/putnam_1989_b6.lean
+++ b/lean4/src/putnam_1989_b6.lean
@@ -9,11 +9,11 @@ Let $(x_1,x_2,\dots,x_n)$ be a point chosen at random from the $n$-dimensional r
 theorem putnam_1989_b6
     (n : ℕ) [NeZero n]
     (I : (Fin n → ℝ) → Fin (n + 2) → ℝ)
-    (I_def : ∀ x i, I x i = if i = 0 then 0 else if i = - 1 then 1 else x (i : ℕ).pred)
+    (I_def : ∀ x, I x = Fin.cons 0 (Fin.snoc x 1))
     (X : Set (Fin n → ℝ))
-    (X_def : ∀ x, x ∈ X ↔ 0 < x 0 ∧ x (-1) < 1 ∧ ∀ i, i + 1 < n → x i < x (i + 1))
+    (X_def : ∀ x, x ∈ X ↔ 0 < x 0 ∧ x (-1) < 1 ∧ StrictMono x)
     (S : (ℝ → ℝ) → (Fin (n + 2) → ℝ) → ℝ)
-    (S_def : ∀ f x, S f x = ∑ i ∈ Finset.Iic n, (x (i + 1) - x i) * f (i + 1)) :
+    (S_def : ∀ f x, S f x = ∑ i : Fin n.succ, (x i.succ - x i.castSucc) * f (i + 1)) :
     ∃ P : Polynomial ℝ,
       P.degree = n ∧
       (∀ t ∈ Icc 0 1, P.eval t ∈ Icc 0 1) ∧

--- a/lean4/src/putnam_2000_b3.lean
+++ b/lean4/src/putnam_2000_b3.lean
@@ -10,11 +10,11 @@ N_0\leq N_1\leq N_2\leq \cdots \mbox{ and } \lim_{k\to\infty} N_k = 2N.
 -/
 theorem putnam_2000_b3
   (N : ℕ) (hN : N > 0)
-  (a : Fin (N + 1) → ℝ)
+  (a : Icc 1 N → ℝ)
   (f : ℝ → ℝ)
   (mult : (ℝ → ℝ) → ℝ → ℕ)
   (M : ℕ → ℕ)
-  (haN : a N ≠ 0)
+  (haN : a ⟨N, by simp; omega⟩ ≠ 0)
   (hf : ∀ t, f t = ∑ j : Icc 1 N, a j * Real.sin (2 * Real.pi * j * t))
   (hmult : ∀ g : ℝ → ℝ, ∀ t : ℝ, (∃ c : ℕ, iteratedDeriv c g t ≠ 0) → (iteratedDeriv (mult g t) g t ≠ 0 ∧ ∀ k < (mult g t), iteratedDeriv k g t = 0))
   (hM : ∀ k, M k = ∑' t : Ico (0 : ℝ) 1, mult (iteratedDeriv k f) t) :

--- a/lean4/src/putnam_2013_a4.lean
+++ b/lean4/src/putnam_2013_a4.lean
@@ -12,8 +12,8 @@ theorem putnam_2013_a4
 (ws : Fin k → Fin n × Fin (n + 1))
 (Zsum Nsum : ℤ)
 (npos : n ≥ 1) (kpos : k ≥ 1)
-(hZ : ∀ w, Z w = ∑ l : {x : Fin n | x < w.2}, if (circle (w.1 + l) = 0) then 1 else 0)
-(hN : ∀ w, N w = ∑ l : {x : Fin n | x < w.2}, if (circle (w.1 + l) = 1) then 1 else 0)
+(hZ : ∀ w, Z w = ∑ l ∈ {x : Fin n | x.1 < w.2.1}, if (circle (w.1 + l) = 0) then 1 else 0)
+(hN : ∀ w, N w = ∑ l ∈ {x : Fin n | x.1 < w.2.1}, if (circle (w.1 + l) = 1) then 1 else 0)
 (Zle1 : ∀ w w', w.2 = w'.2 → |(Z w : ℤ) - Z w'| ≤ 1)
 (hZsum : Zsum = ((1 : ℝ) / k) * ∑ j : Fin k, Z (ws j))
 (hNsum : Nsum = ((1 : ℝ) / k) * ∑ j : Fin k, N (ws j)) :

--- a/lean4/src/putnam_2023_b3.lean
+++ b/lean4/src/putnam_2023_b3.lean
@@ -10,8 +10,8 @@ A sequence $y_1, y_2, \ldots, y_k$ of real numbers is called zigzag if $k = 1$, 
 theorem putnam_2023_b3
     (IsZigZag : {k : ℕ} → (Fin k → ℝ) → Prop)
     (IsZigZag_def : ∀ (k : ℕ) [NeZero k] (y : Fin k → ℝ),
-      IsZigZag y ↔ k = 1 ∨ ((∀ i, i + 1 < k → y (i + 1) ≠ y i)) ∧
-        (∀ i, i + 2 < k → (y (i + 2) < y (i + 1) ↔ y i < y (i + 1))))
+      IsZigZag y ↔ k = 1 ∨ ((∀ i : Fin k, i + 1 < k → y (i + 1) ≠ y i)) ∧
+        (∀ i : Fin k, i + 2 < k → (y (i + 2) < y (i + 1) ↔ y i < y (i + 1))))
     (n : ℕ)
     (hn : 2 ≤ n)
     (a : (Fin n → Icc (0 : ℝ) 1) → ℕ)


### PR DESCRIPTION
The new behavior can be emulated with `attribute [-instance] Fin.instCommRing Fin.instNatCast Fin.instAddMonoidWithOne`.

While the old behavior can be kept with `open scoped Fin.CommRing`, the spelling without is usually clearer anyway.