### PR TITLE
fix: Putnam 2007 B3 wrong answer

### DIFF
--- a/coq/src/putnam_2007_b3.v
+++ b/coq/src/putnam_2007_b3.v
@@ -1,5 +1,5 @@
 Require Import Reals Coquelicot.Coquelicot.
-Definition putnam_2007_b3_solution := let a := (1 + sqrt 5) / 2 in (2 ^ 2006 / sqrt 5) * (a ^ 3997 - Rpower a (-3997)).
+Definition putnam_2007_b3_solution := let a := (1 + sqrt 5) / 2 in (2 ^ 2006 / sqrt 5) * (a ^ 4017 + Rpower a (-4017)).
 Theorem putnam_2007_b3
     (X := fix x (n: nat) :=
         match n with

--- a/isabelle/putnam_2007_b3.thy
+++ b/isabelle/putnam_2007_b3.thy
@@ -3,7 +3,7 @@ Complex_Main
 begin
 
 definition putnam_2007_b3_solution :: real where "putnam_2007_b3_solution \<equiv> undefined"
-(* (2 ^ 2006 / sqrt 5) * ((((1 + sqrt 5) / 2) powr 3997) - (((1 + sqrt 5) / 2) powr -3997)) *)
+(* (2 ^ 2006 / sqrt 5) * ((((1 + sqrt 5) / 2) powr 4017) + (((1 + sqrt 5) / 2) powr -4017)) *)
 theorem putnam_2007_b3:
   fixes x :: "nat \<Rightarrow> real"
   assumes hx0: "x 0 = 1"

--- a/lean4/src/putnam_2007_b3.lean
+++ b/lean4/src/putnam_2007_b3.lean
@@ -3,7 +3,7 @@ import Mathlib
 open Set Nat Function
 
 noncomputable abbrev putnam_2007_b3_solution : ℝ := sorry
--- (2 ^ 2006 / Real.sqrt 5) * (((1 + Real.sqrt 5) / 2) ^ 3997 - ((1 + Real.sqrt 5) / 2) ^ (-3997 : ℤ))
+-- (2 ^ 2006 / Real.sqrt 5) * (((1 + Real.sqrt 5) / 2) ^ 4017 + ((1 + Real.sqrt 5) / 2) ^ (-4017 : ℤ))
 /--
 Let $x_0 = 1$ and for $n \geq 0$, let $x_{n+1} = 3x_n + \lfloor x_n \sqrt{5} \rfloor$. In particular, $x_1 = 5$, $x_2 = 26$, $x_3 = 136$, $x_4 = 712$. Find a closed-form expression for $x_{2007}$. ($\lfloor a \rfloor$ means the largest integer $\leq a$.)
 -/


### PR DESCRIPTION
For alpha = (1+sqrt5)/2, the Binet formula states that F_k = (alpha^k - (-alpha)^(-k)) / sqrt5, with the minus sign inside the ^(-k) part. Hence when k = 2n+3, one should get F_(2n+3) = (alpha^(2n+3) + alpha^(-(2n+3))) / sqrt5. Note the flipped sign relative to the stated answer of alpha^(2n+3) - alpha^(-(2n+3)).

More frivolously, for n = 2007 we have 2n+3 = 4017 rather than 3997.
