### PR TITLE
Fix formalizations of 11 problems

### DIFF
--- a/lean4/src/putnam_1962_a2.lean
+++ b/lean4/src/putnam_1962_a2.lean
@@ -3,7 +3,7 @@ import Mathlib
 open MeasureTheory Set
 
 abbrev putnam_1962_a2_solution : Set (ℝ → ℝ) := sorry
--- {f : ℝ → ℝ | ∃ a c : ℝ, a ≥ 0 ∧ f = fun x ↦ a / (1 - c * x) ^ 2}
+-- {f | (∃ a c : ℝ, 0 ≤ a ∧ f = (fun x : ℝ ↦ a / (1 - c * x) ^ 2)) ∨ (∃ a c : ℝ, 0 ≤ a ∧ 0 < c ∧ f = (fun x : ℝ ↦ if x < 1 / c then a / (1 - c * x) ^ 2 else 0)) ∨ (0 ≤ f ∧ ∀ x : ℝ, 0 < x → f x = 0) ∨ (∃ e : ℝ, 0 < e ∧ f 0 = 0 ∧ 0 ≤ f ∧ ∀ x ∈ Ioo (0 : ℝ) e, (⨍ t in Ico (0 : ℝ) x, f t) = 0)}
 /--
 Find every real-valued function $f$ whose domain is an interval $I$ (finite or infinite) having 0 as a left-hand endpoint, such that for every positive member $x$ of $I$ the average of $f$ over the closed interval $[0, x]$ is equal to the geometric mean of the numbers $f(0)$ and $f(x)$.
 -/

--- a/lean4/src/putnam_1963_a3.lean
+++ b/lean4/src/putnam_1963_a3.lean
@@ -14,7 +14,8 @@ theorem putnam_1963_a3
     (hn : 0 < n)
     (f y : ℝ → ℝ)
     (hf : ContinuousOn f (Ici 1))
-    (hy : ContDiffOn ℝ n y (Ici 1)) :
+    (hy : ContDiffOn ℝ n y (Ici 1))
+    (hy1 : ContDiffAt ℝ n y 1) :
     (∀ i < n, deriv^[i] y 1 = 0) ∧ (Ici 1).EqOn (P n y) f ↔
     ∀ x ≥ 1, y x = ∫ t in (1 : ℝ)..x, putnam_1963_a3_solution f n x t :=
   sorry

--- a/lean4/src/putnam_1967_a4.lean
+++ b/lean4/src/putnam_1967_a4.lean
@@ -8,5 +8,5 @@ Show that if $\lambda > \frac{1}{2}$ there does not exist a real-valued function
 theorem putnam_1967_a4
 (lambda : ℝ)
 (hlambda : lambda > 1 / 2)
-: ¬∃ u : ℝ → ℝ, ∀ x ∈ Set.Icc 0 1, u x = 1 + lambda * (∫ y in Set.Ioo x 1, u y * u (y - x)) :=
+: ¬∃ u : ℝ → ℝ, MeasureTheory.IntegrableOn u (Set.Icc 0 1) ∧ ∀ x ∈ Set.Icc 0 1, u x = 1 + lambda * (∫ y in Set.Ioo x 1, u y * u (y - x)) :=
 sorry

--- a/lean4/src/putnam_1967_b6.lean
+++ b/lean4/src/putnam_1967_b6.lean
@@ -9,6 +9,7 @@ Let $f$ be a real-valued function having partial derivatives and which is define
 theorem putnam_1967_b6
 (f : ℝ → ℝ → ℝ)
 (fdiff : (∀ y : ℝ, Differentiable ℝ (fun x : ℝ => f x y)) ∧ (∀ x : ℝ, Differentiable ℝ (fun y : ℝ => f x y)))
+(fcont : ContinuousOn (fun p : ℝ × ℝ => f p.1 p.2) {p : ℝ × ℝ | p.1 ^ 2 + p.2 ^ 2 ≤ 1})
 (fbound : ∀ x y : ℝ, (x ^ 2 + y ^ 2 ≤ 1) → |f x y| ≤ 1)
 : ∃ x0 y0 : ℝ, (x0 ^ 2 + y0 ^ 2 < 1) ∧ ((deriv (fun x : ℝ => f x y0) x0) ^ 2 + (deriv (fun y : ℝ => f x0 y) y0) ^ 2 ≤ 16) :=
 sorry

--- a/lean4/src/putnam_1968_a3.lean
+++ b/lean4/src/putnam_1968_a3.lean
@@ -15,5 +15,5 @@ theorem putnam_1968_a3
     ∃ (n : ℕ) (s : Fin (2 ^ n) → Set α),
       s 0 = ∅ ∧
       (∀ t, ∃! i, s i = t) ∧
-      (∀ i, i + 1 < 2 ^ n → (s i ∆ s (i + 1)).ncard = 1) :=
+      (∀ i, i.1 + 1 < 2 ^ n → (s i ∆ s (i + 1)).ncard = 1) :=
   sorry

--- a/lean4/src/putnam_1968_b4.lean
+++ b/lean4/src/putnam_1968_b4.lean
@@ -8,5 +8,5 @@ Suppose that $f : \mathbb{R} \to \mathbb{R}$ is continuous on $(-\infty, \infty)
 theorem putnam_1968_b4
 (f : ℝ → ℝ)
 (hf : Continuous f ∧ ∃ r : ℝ, Tendsto (fun y => ∫ x in ball 0 y, f x) atTop (𝓝 r))
-: ∃ r : ℝ, Tendsto (fun y => ∫ x in ball 0 y, f (x - 1/x)) atTop (𝓝 r) ∧ Tendsto (fun y => ∫ x in ball 0 y, f x) atTop (𝓝 r) :=
+: ∃ r : ℝ, Tendsto (fun y => ∫ x in (ball 0 y \ ball 0 (1 / y)), f (x - 1/x)) atTop (𝓝 r) ∧ Tendsto (fun y => ∫ x in ball 0 y, f x) atTop (𝓝 r) :=
 sorry

--- a/lean4/src/putnam_1976_b3.lean
+++ b/lean4/src/putnam_1976_b3.lean
@@ -21,6 +21,8 @@ theorem putnam_1976_b3
 (events : Fin n → Set Ω)
 (heventsmeas : ∀ i : Fin n, MeasurableSet (events i))
 (heventsprob : ∀ i : Fin n, μ (events i) ≥ ENNReal.ofReal (1 - a))
-(heventsindep : ∀ i j : Fin n, |(i : ℤ) - (j : ℤ)| > 1 → IndepSet (events i) (events j) μ)
+(heventsindep : ∀ i : Fin n,
+  ProbabilityTheory.Indep (MeasurableSpace.generateFrom {events i})
+    (MeasurableSpace.generateFrom (Set.image events {j : Fin n | (j : ℤ) < (i : ℤ) - 1})) μ)
 : μ (⋂ i : Fin n, events i) ≥ ENNReal.ofReal (u n) :=
 sorry

--- a/lean4/src/putnam_1978_a3.lean
+++ b/lean4/src/putnam_1978_a3.lean
@@ -16,5 +16,5 @@ theorem putnam_1978_a3
     (hp : p = 2 * (X ^ 6 + 1) + 4 * (X ^ 5 + X) + 3 * (X ^ 4 + X ^ 2) + 5 * X ^ 3)
     (I : ℕ → ℝ)
     (hI : I = fun k ↦ ∫ x in Ioi 0, x ^ k / p.eval x) :
-    IsLeast {y | ∃ k ∈ Ioo 0 5, I k = y} putnam_1978_a3_solution :=
+    IsLeast {y | ∃ k ∈ Ioo 0 5, I k = y} (I putnam_1978_a3_solution) :=
   sorry

--- a/lean4/src/putnam_2005_a3.lean
+++ b/lean4/src/putnam_2005_a3.lean
@@ -14,6 +14,6 @@ theorem putnam_2005_a3
     (pzeros : ∀ z : ℂ, p.eval z = 0 → ‖z‖ = 1)
     (hg : ∀ z : ℂ, g z = (p.eval z) / z ^ ((n : ℂ) / 2))
     (z : ℂ)
-    (hz : z ≠ 0 ∧ deriv g z = 0) :
+    (hz : z ≠ 0 ∧ DifferentiableAt ℂ g z ∧ deriv g z = 0) :
     ‖z‖ = 1 :=
   sorry

--- a/lean4/src/putnam_2011_a1.lean
+++ b/lean4/src/putnam_2011_a1.lean
@@ -13,7 +13,7 @@ How many of the points $(x,y)$ with integer coordinates $0 \leq x \leq 2011,0 \l
 theorem putnam_2011_a1
   (IsSpiral : List (Fin 2 → ℤ) → Prop)
   (IsSpiral_def : ∀ P, IsSpiral P ↔ P.length ≥ 3 ∧ P[0]! = 0 ∧
-  (∃ l : Fin (P.length - 1) → ℕ, l > 0 ∧ StrictMono l ∧ (∀ i : Fin (P.length - 1),
+  (∃ l : Fin (P.length - 1) → ℕ, (∀ i, 0 < l i) ∧ StrictMono l ∧ (∀ i : Fin (P.length - 1),
     (i.1 % 4 = 0 → (P[i] 0 + l i = P[i.1 + 1]! 0 ∧ P[i] 1 = P[i.1 + 1]! 1)) ∧
     (i.1 % 4 = 1 → (P[i] 0 = P[i.1 + 1]! 0 ∧ P[i] 1 + l i = P[i.1 + 1]! 1)) ∧
     (i.1 % 4 = 2 → (P[i] 0 - l i = P[i.1 + 1]! 0 ∧ P[i] 1 = P[i.1 + 1]! 1)) ∧

--- a/lean4/src/putnam_2023_b4.lean
+++ b/lean4/src/putnam_2023_b4.lean
@@ -20,7 +20,7 @@ theorem putnam_2023_b4
     (htne : ∀ n ts, tne n ts = {t | t > ts 0 ∧ ∀ i : Fin n, t ≠ ts (i.1 + 1)}) :
     IsLeast
     {(T : ℝ) | 0 ≤ T ∧ ∃ (n : ℕ) (ts : ℕ → ℝ) (f : ℝ → ℝ),
-      ∀ k : Fin n, ts (k.1 + 1) ≥ ts k.1 + 1 ∧
+      (∀ k : Fin n, ts (k.1 + 1) ≥ ts k.1 + 1) ∧
       ContinuousOn f (Set.Ici (ts 0)) ∧
       ContDiffOn ℝ 1 f (tne n ts) ∧
       DifferentiableOn ℝ (derivWithin f (tne n ts)) (tne n ts) ∧


### PR DESCRIPTION
Fix 11 problems

putnam_1962_a2:

The original Putnam solution provides the main family f(x) = b/(cx+1)² but omits degenerate cases that rigorously satisfy the functional equation. When f(0)·f(x) = 0, both the average and geometric mean equal zero, allowing functions not expressible in the rational form. The formalization correctly identifies these edge cases: zero functions, functions with f(0) = 0 and zero integral, and truncated versions on finite intervals where the rational function has singularities beyond the domain boundary.

Counterexample to Original Solution:

Consider the "spike at zero" function:
f(x) = { 1  if x = 0
         { 0  if x > 0

  This clearly satisfies the problem statement: for any x > 0, the average equals (1/x)∫₀ˣ 0 dt = 0, and √(f(0)·f(x)) = √(1·0) = 0, so both sides equal zero. However, this function is not of the form b/(cx+1)² for any choice of parameters b and c, demonstrating that the original solution is incomplete.

  A more pathological example: any non-negative function with f(0) = 0 that is zero almost everywhere (e.g., f(x) = 1 only at rational points in [0,1], zero elsewhere) also satisfies the equation since both the integral and geometric mean vanish, yet cannot be expressed in the rational form.

putnam_2011_a1:
Changed length positivity condition: l > 0 → (∀ i, 0 < l i) - The English problem states "the lengths of these line segments are positive and strictly increasing," where "positive" applies to all segment lengths (plural).
Due to Lean's Pi ordering instance for function types, the expression l > 0 (where l : Fin n → ℕ) means "there exists at least one index i where l(i) > 0" rather than "for all indices i, l(i) > 0". Specifically, by Pi.lt_def, the condition 0 < l expands to (0 ≤ l) ∧ (∃ i, 0 < l i).
This semantic error allowed spirals with zero-length segments (e.g., lengths [1, 0, 2, 3, 4]) that violate the problem statement. The buggy formalization makes more points reachable (by allowing "cheat" moves with zero-length segments), which reduces the count of unreachable points from the correct answer of 10053 to an incorrect 6033. We have a complete formal proof of the buggy formalization producing 6033, demonstrating that the incorrect statement is provable but solves the wrong problem. The corrected formalization (∀ i, 0 < l i) properly requires every segment length to be positive, matching the mathematical requirement and yielding the correct answer of 10053.

putnam_2023_b4:
Fixed quantifier scope: ∀ k : Fin n, ts (k.1 + 1) ≥ ts k.1 + 1 ∧ ContinuousOn f ... → (∀ k : Fin n, ts (k.1 + 1) ≥ ts k.1 + 1) ∧ ContinuousOn f …
Due to Lean's operator precedence, the original expression parses as ∀ k : Fin n, [spacing constraint ∧ continuity ∧ differentiability ∧ f(t₀) = 1/2 ∧ ... ∧ f(t₀ + T) = 2023], making the universal quantifier scope over all conditions including the target equation. By adding parentheses, the corrected version restricts the quantifier to only the spacing constraint, placing the function properties outside: (∀ k : Fin n, spacing constraint) ∧ continuity ∧ ... ∧ f(t₀ + T) = 2023.
With the incorrect scoping, when n = 0, the type Fin 0 is empty, making ∀ k : Fin 0, [...] vacuously true regardless of the bracketed conditions. This allowed T = 0 to satisfy the formalization because the target equation f(t₀ + T) = 2023 was inside the vacuous quantifier and never actually checked. With the corrected scoping, f(t₀ + T) = 2023 must be genuinely satisfied, forcing the function to grow from 1/2 to 2023, which requires T ≥ 29.
Without this fix, the formalization gave answer 0 instead of the correct answer 29. We have a formal proof of that as well.

putnam_1968_a3:
Fixed adjacency condition to use natural number arithmetic: (∀ i, i + 1 < 2 ^ n → ...) → (∀ i, i.1 + 1 < 2 ^ n → ...)
The English problem asks to prove there exists a list of subsets where "each successive element in the list is formed by adding or removing one element from the previous subset in the list."
In the original expression (∀ i, i + 1 < 2 ^ n → ...), the variable i is implicitly typed as Fin (2^n) based on the context (since s : Fin (2^n) → Set α). Due to Lean's Fin type arithmetic, the expression i + 1 performs modular addition: it computes (i.val + 1) % (2^n), causing the last index to wrap back to 0.
The corrected formalization uses i.1 + 1, where i.1 extracts the underlying natural number before addition, preventing wraparound. With this fix, when i is the last index, the condition evaluates to false (since (2^n - 1).1 + 1 = 2^n, which is not less than 2^n), correctly capturing that a list has a terminal element with no successor.

putnam_1963_a3:
Added boundary point differentiability hypothesis: (hy : ContDiffOn ℝ n y (Ici 1)) → (hy : ContDiffOn ℝ n y (Ici 1)) (hy1 : ContDiffAt ℝ n y 1)
The original formalization only requires ContDiffOn ℝ n y (Ici 1), which states that y is C^n on the interval [1, ∞). In Lean's definition, ContDiffOn for a function on a set only guarantees one-sided differentiability at boundary points—at x=1, this means derivatives are defined only from the right (using limits as h→0+). However, Lean's deriv operator is defined using standard (two-sided) derivatives, not one-sided derivatives.
The theorem statement requires evaluating deriv^[i] y 1 = 0 for i < n (the initial conditions y(1) = y'(1) = ... = y^(n-1)(1) = 0). Without the added hypothesis ContDiffAt ℝ n y 1, these derivative expressions are not well-defined at the boundary point x=1 in Lean's type system. The ContDiffAt hypothesis explicitly ensures that y has standard (two-sided) C^n smoothness at x=1, allowing the proof to evaluate and manipulate deriv^[i] y 1 as concrete values. This is a technically necessary formalization requirement that makes explicit what the original English problem implicitly assumes—any solution satisfying the stated initial conditions must be genuinely differentiable at x=1.

putnam_1967_a4
Added integrability hypothesis to existential statement: ¬∃ u : ℝ → ℝ, ∀ x ∈ Set.Icc 0 1, u x = 1 + lambda * (...) → ¬∃ u : ℝ → ℝ, MeasureTheory.IntegrableOn u (Set.Icc 0 1) ∧ ∀ x ∈ Set.Icc 0 1, u x = 1 + lambda * (...)
The English problem asks to show that no function u satisfies the integral equation u(x) = 1 + λ∫ₓ¹ u(y)u(y-x)dy for λ > 1/2. The original formalization quantifies over all functions ℝ → ℝ, but in Lean's measure theory (Mathlib), the integral ∫ y in Set.Ioo x 1, u y * u (y - x) is only well-defined when u is integrable. For non-integrable functions, this integral may evaluate to ±∞ or remain undefined, making the equation itself meaningless.

putnam_1968_b4:
Modified integration domain to exclude neighborhood of singularity: ∫ x in ball 0 y, f (x - 1/x) → ∫ x in (ball 0 y \ ball 0 (1 / y)), f (x - 1/x)
The English problem asks to prove ∫{-∞}^{∞} f(x - 1/x) dx = ∫{-∞}^{∞} f(x) dx for continuous f with convergent integral. The transformation x ↦ x - 1/x is undefined at x = 0 in standard mathematics (it involves 1/0).
The original Lean4 statement type-checks because Lean defines 1/0 = 0 by convention, making x - 1/x artificially total. This allows syntactically forming ∫ x in ball 0 y, f (x - 1/x), but the statement does not faithfully represent the mathematical problem. In real mathematics, you would not integrate a transformation over points where it is undefined.
Additionally, the artificially extended function is discontinuous at x = 0 (approaching -∞ from the right and +∞ from the left in standard mathematics, regardless of Lean's totality convention), with an unbounded derivative (1 + 1/x²). Change-of-variables theorems require continuous differentiability, making the original statement unprovable with standard techniques.
The modified formalization excludes the ball of radius 1/y around x = 0, working only where the transformation is mathematically defined. As y → ∞, the excluded region shrinks to {0}. This modification both makes the statement provable and provides a faithful formalization of the original mathematical problem, which implicitly works only where x - 1/x makes sense.

putnam_2005_a3:
Added differentiability hypothesis: (hz : z ≠ 0 ∧ deriv g z = 0) → (hz : z ≠ 0 ∧ DifferentiableAt ℂ g z ∧ deriv g z = 0)

The English problem asks to show that all "zeros of g'(z)" have absolute value 1. Mathematically, this means points where g is differentiable AND g'(z) = 0. However, in Lean's formalization, deriv g z returns 0 by convention when g is not differentiable at z (to avoid partiality). This creates a critical issue: the original statement deriv g z = 0 is satisfied both at genuine critical points and at non-differentiable points where deriv artificially returns 0.
The added hypothesis DifferentiableAt ℂ g z explicitly restricts to points where g is genuinely differentiable, correctly capturing the mathematical meaning of "zeros of g'" from the original problem.

putnam_1978_a3
Modified conclusion to apply function to solution index:
IsLeast {y | ∃ k ∈ Ioo 0 5, I k = y} putnam_1978_a3_solution
→
IsLeast {y | ∃ k ∈ Ioo 0 5, I k = y} (I putnam_1978_a3_solution)
The English problem asks: "For which k is I_k smallest?" where I_k = ∫₀^∞ x^k/p(x) dx for k ∈ {1,2,3,4}. The answer is k = 2, represented by putnam_1978_a3_solution : ℕ := 2.
The original formalization contains a type error. The predicate IsLeast S a asserts that a is the minimum element of the set S. Here, the set is {y | ∃ k ∈ Ioo 0 5, I k = y}, which contains real-valued integrals (I(1), I(2), I(3), I(4)). The original statement claims that putnam_1978_a3_solution (the natural number 2) is the minimum element of this set of real numbers.
This is a category error: it asserts that the index 2 is the minimum value among the integrals, rather than asserting that the integral at index 2 (i.e., I(2)) has the minimum value. The number 2 is not even an element of the set of integral values—it's the argument that produces the minimal value.
The modification applies the function I to the solution index, changing the claim from "2 is the minimum value" to "I(2) is the minimum value." This correctly captures the mathematical statement: among all integrals I(k) for k ∈ {1,2,3,4}, the value I(2) is the smallest.

**Special cases:**

putnam_1976_b3
Modified independence condition from pairwise to collective:
Original:
(heventsindep : ∀ i j : Fin n, |(i : ℤ) - (j : ℤ)| > 1 → IndepSet (events i) (events j) μ)
Modified:
(heventsindep : ∀ i : Fin n,
  ProbabilityTheory.Indep (MeasurableSpace.generateFrom {events i})
    (MeasurableSpace.generateFrom (Set.image events {j : Fin n | (j : ℤ) < (i : ℤ) - 1})) μ)
The original formalization uses pairwise independence: any two events A_i and A_j with |i-j| > 1 are independent. However, the proof requires that each event A_k is independent of the intersection ⋂_{j<k-1} A_j (all earlier non-adjacent events occurring together). Pairwise independence does NOT imply this collective independence property.
The official Putnam solution confirms this flaw: "This was a rare Putnam disaster - the question is wrong... A_{n+1} is independent of the event (all of A_1, ... , A_{n-1} occur)... does not follow from the fact that A_{n+1} is independent of each of A_1, ... , A_{n-1}."
The modified formalization requires each event A_i to be independent of the σ-algebra generated by all events A_j with j < i-1. This ensures A_i is independent of any measurable set in that σ-algebra, including the critical intersection ⋂_{j<i-1} A_j. The condition (j : ℤ) < (i : ℤ) - 1 captures only independence from earlier events at distance > 1, which is precisely what the proof needs. The original statement with only pairwise independence is unprovable.

putnam_1967_b6:
Added continuity hypothesis: (fcont : ContinuousOn (fun p : ℝ × ℝ => f p.1 p.2) putnam_1967_b6_D)
The English problem asks to show that for a real-valued function f with partial derivatives defined on the closed unit disk x² + y² ≤ 1 with |f(x,y)| ≤ 1, there exists an interior point (x₀,y₀) where (∂f/∂x)² + (∂f/∂y)² ≤ 16.
The original Lean4 formalization assumes only separate differentiability: f is differentiable in x for each fixed y, and differentiable in y for each fixed x. While this implies that f is continuous along every horizontal and vertical line (separate continuity), it does NOT imply that f is jointly continuous as a function of two variables. Classic counterexample: f(x,y) = 2xy/(x² + y²) for (x,y) ≠ (0,0), f(0,0) = 0 has partial derivatives at the origin but is discontinuous there (approaching (0,0) along y = x gives a different limit than the function value).
The standard proof strategy—used in both the official Putnam solution and the agent's proof—constructs the auxiliary function h(x,y) = f(x,y) + 2x² + 2y² and observes that:
    (1) h(0,0) = f(0,0) ≤ 1 at the center
    (2) h(x,y) = f(x,y) + 2 ≥ -1 + 2 = 1 on the boundary
The proof then invokes the Extreme Value Theorem to conclude that h must attain its minimum (which is ≤ 1) at some interior point, where the gradient must vanish: ∇h = 0. This critical point equation yields ∂f/∂x = 4x and ∂f/∂y = 4y, giving (∂f/∂x)² + (∂f/∂y)² = 16(x² + y²) < 16 in the interior.
Without joint continuity, the Extreme Value Theorem does not apply. A bounded function with partial derivatives everywhere on a compact set is NOT guaranteed to attain its extrema—it might only approach the infimum/supremum without reaching it. The official solution's statement "it is either constant at an interior point of D or has a minimum at an interior point" implicitly invokes the EVT and thus assumes continuity.