### PR TITLE
Move Humanfia result to with-answer track

### DIFF
--- a/docs/results.json
+++ b/docs/results.json
@@ -406,7 +406,7 @@
         "link": "https://github.com/humanfia/putnambench-solver",
         "open-data": "PARTIAL",
         "num-solved": {
-            "lean-nosolution": 670
+            "lean-wsolution": 670
         },
         "size": 0,
         "condensed-compute-budget": "Avg $44.6 total cost/problem",


### PR DESCRIPTION
## Summary
- move Humanfia (w/ GPT 5.5) from the Lean no-answer track to the with-answer track
- preserve the reported score of 670

## Validation
- `jq empty docs/results.json`
- `git diff --check`